### PR TITLE
30 coroutine generator unit test cases occasionally crash on linux

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "master" , "Release-**" , "Test"]
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
     branches: [ "master" , "Release-**"]
   release:
     types: [published]

--- a/ActivityFramework/CMakeLists.txt
+++ b/ActivityFramework/CMakeLists.txt
@@ -47,7 +47,6 @@ add_library(ActivityFramework SHARED
     Src/Components/TA_PipelineCreator.cpp
     Src/Components/TA_PipelineCreator.h
     Src/Components/TA_PipelineHolder.h
-    Src/Components/TA_ReceiverObject.h
     Src/Components/TA_TypeFilter.h
     Src/Components/TA_TypeList.h
     Src/Components/TA_Variant.h

--- a/ActivityFramework/Src/Components/TA_Activity.h
+++ b/ActivityFramework/Src/Components/TA_Activity.h
@@ -288,6 +288,10 @@ class TA_ActivityCreator {
 class TA_ActivityFetcherAwaitable : public std::enable_shared_from_this<TA_ActivityFetcherAwaitable> {
   public:
     TA_ActivityFetcherAwaitable() = default;
+    TA_ActivityFetcherAwaitable(const TA_ActivityFetcherAwaitable &) = delete;
+    TA_ActivityFetcherAwaitable(TA_ActivityFetcherAwaitable &&) = delete;
+    TA_ActivityFetcherAwaitable &operator=(const TA_ActivityFetcherAwaitable &) = delete;
+    TA_ActivityFetcherAwaitable &operator=(TA_ActivityFetcherAwaitable &&) = delete;
 
     explicit TA_ActivityFetcherAwaitable(TA_ActivityProxy *pActivity) : m_pProxy(pActivity) {
         if (!m_pProxy || !m_pProxy->isValid()) {
@@ -301,6 +305,8 @@ class TA_ActivityFetcherAwaitable : public std::enable_shared_from_this<TA_Activ
             m_pProxy = nullptr;
         }
     }
+
+    TA_ActivityFetcherAwaitable &operator co_await() & noexcept { return *this; }
 
     bool await_ready() noexcept {
         m_isRunning.store(true, std::memory_order_release);
@@ -356,12 +362,19 @@ class TA_ActivityExecutingAwaitable : public std::enable_shared_from_this<TA_Act
         }
     }
 
+    TA_ActivityExecutingAwaitable(const TA_ActivityExecutingAwaitable &) = delete;
+    TA_ActivityExecutingAwaitable(TA_ActivityExecutingAwaitable &&) = delete;
+    TA_ActivityExecutingAwaitable &operator=(const TA_ActivityExecutingAwaitable &) = delete;
+    TA_ActivityExecutingAwaitable &operator=(TA_ActivityExecutingAwaitable &&) = delete;
+
     ~TA_ActivityExecutingAwaitable() {
         if (m_pProxy && !m_pProxy->isExecuted()) {
             delete m_pProxy;
             m_pProxy = nullptr;
         }
     }
+
+    TA_ActivityExecutingAwaitable &operator co_await() & noexcept { return *this; }
 
     bool await_ready() const noexcept { return m_pProxy->isExecuted() || !m_pProxy->isValid(); }
 

--- a/ActivityFramework/Src/Components/TA_Activity.h
+++ b/ActivityFramework/Src/Components/TA_Activity.h
@@ -293,18 +293,13 @@ class TA_ActivityFetcherAwaitable : public std::enable_shared_from_this<TA_Activ
     TA_ActivityFetcherAwaitable &operator=(const TA_ActivityFetcherAwaitable &) = delete;
     TA_ActivityFetcherAwaitable &operator=(TA_ActivityFetcherAwaitable &&) = delete;
 
-    explicit TA_ActivityFetcherAwaitable(TA_ActivityProxy *pActivity) : m_pProxy(pActivity) {
+    explicit TA_ActivityFetcherAwaitable(std::shared_ptr<TA_ActivityProxy> pActivity) : m_pProxy(pActivity) {
         if (!m_pProxy || !m_pProxy->isValid()) {
             throw std::runtime_error("TA_ActivityFetcherAwaitable: Activity Proxy is not valid!");
         }
     }
 
-    ~TA_ActivityFetcherAwaitable() {
-        if (m_pProxy && !m_pProxy->isExecuted()) {
-            delete m_pProxy;
-            m_pProxy = nullptr;
-        }
-    }
+    ~TA_ActivityFetcherAwaitable() = default;
 
     TA_ActivityFetcherAwaitable &operator co_await() & noexcept { return *this; }
 
@@ -347,7 +342,7 @@ class TA_ActivityFetcherAwaitable : public std::enable_shared_from_this<TA_Activ
 
   private:
     std::atomic_bool m_isRunning{false};
-    TA_ActivityProxy *m_pProxy{nullptr};
+    std::shared_ptr<TA_ActivityProxy> m_pProxy{nullptr};
     std::shared_ptr<TA_DefaultVariant> m_res{};
 };
 
@@ -355,7 +350,7 @@ class TA_ActivityExecutingAwaitable : public std::enable_shared_from_this<TA_Act
   public:
     enum class ExecuteType { Async, Sync };
 
-    TA_ActivityExecutingAwaitable(TA_ActivityProxy *pActivity, ExecuteType type)
+    TA_ActivityExecutingAwaitable(std::shared_ptr<TA_ActivityProxy> pActivity, ExecuteType type)
         : m_pProxy(pActivity), m_executeType(type) {
         if (!m_pProxy) {
             throw std::runtime_error("TA_ActivityExecutingAwaitable: pActivity is null!");
@@ -367,13 +362,7 @@ class TA_ActivityExecutingAwaitable : public std::enable_shared_from_this<TA_Act
     TA_ActivityExecutingAwaitable &operator=(const TA_ActivityExecutingAwaitable &) = delete;
     TA_ActivityExecutingAwaitable &operator=(TA_ActivityExecutingAwaitable &&) = delete;
 
-    ~TA_ActivityExecutingAwaitable() {
-        if (m_pProxy && !m_pProxy->isExecuted()) {
-            delete m_pProxy;
-            m_pProxy = nullptr;
-        }
-    }
-
+    ~TA_ActivityExecutingAwaitable() = default;
     TA_ActivityExecutingAwaitable &operator co_await() & noexcept { return *this; }
 
     bool await_ready() const noexcept { return m_pProxy->isExecuted() || !m_pProxy->isValid(); }
@@ -382,10 +371,8 @@ class TA_ActivityExecutingAwaitable : public std::enable_shared_from_this<TA_Act
         if (m_executeType == ExecuteType::Async) {
             m_fetcher = TA_ThreadHolder::get().postActivity(m_pProxy);
         } else {
-            std::shared_ptr<TA_ActivityProxy> sharedProxy(std::make_shared<TA_ActivityProxy>(m_pProxy));
-            m_pProxy = nullptr;
-            sharedProxy->operator()();
-            m_fetcher = {sharedProxy};
+            m_pProxy->operator()();
+            m_fetcher = {m_pProxy};
         }
         handle.resume();
     }
@@ -393,7 +380,7 @@ class TA_ActivityExecutingAwaitable : public std::enable_shared_from_this<TA_Act
     auto await_resume() const noexcept { return m_fetcher; }
 
   private:
-    TA_ActivityProxy *m_pProxy{nullptr};
+    std::shared_ptr<TA_ActivityProxy> m_pProxy{nullptr};
     ExecuteType m_executeType{ExecuteType::Async};
     TA_ActivityResultFetcher m_fetcher{};
 };

--- a/ActivityFramework/Src/Components/TA_ActivityProxy.h
+++ b/ActivityFramework/Src/Components/TA_ActivityProxy.h
@@ -87,7 +87,9 @@ class TA_ActivityProxy : public std::enable_shared_from_this<TA_ActivityProxy> {
           m_pIdExp(std::exchange(other.m_pIdExp, nullptr)),
           m_pMoveThreadExp(std::exchange(other.m_pMoveThreadExp, nullptr)),
           m_pStolenEnabledExp(std::exchange(other.m_pStolenEnabledExp, nullptr)),
-          m_future(std::move(other.m_future)) {}
+          m_promise(std::move(other.m_promise)),
+          m_future(std::move(other.m_future)),
+          m_isExecuted(other.m_isExecuted.load()) {}
 
     TA_ActivityProxy &operator=(const TA_ActivityProxy &other) = delete;
     TA_ActivityProxy &operator=(TA_ActivityProxy &&other) noexcept {
@@ -99,7 +101,9 @@ class TA_ActivityProxy : public std::enable_shared_from_this<TA_ActivityProxy> {
             m_pIdExp = std::exchange(other.m_pIdExp, nullptr);
             m_pMoveThreadExp = std::exchange(other.m_pMoveThreadExp, nullptr);
             m_pStolenEnabledExp = std::exchange(other.m_pStolenEnabledExp, nullptr);
+            m_promise = std::move(other.m_promise);
             m_future = std::move(other.m_future);
+            m_isExecuted.store(other.m_isExecuted.load());
         }
         return *this;
     }

--- a/ActivityFramework/Src/Components/TA_ActivityProxy.h
+++ b/ActivityFramework/Src/Components/TA_ActivityProxy.h
@@ -126,7 +126,7 @@ class TA_ActivityProxy : public std::enable_shared_from_this<TA_ActivityProxy> {
         }
         bool expected{false};
         if (m_isExecuted.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-            m_pExecuteExp(m_pActivity, std::forward<std::promise<TA_DefaultVariant>>(m_promise));
+            m_pExecuteExp(m_pActivity, std::move(m_promise));
             m_pExecuteExp = nullptr;
         }
     }

--- a/ActivityFramework/Src/Components/TA_ActivityProxy.h
+++ b/ActivityFramework/Src/Components/TA_ActivityProxy.h
@@ -33,7 +33,7 @@ concept ActivityType = requires(T t, const T ct) {
     requires !IsTrivalCopyable<std::decay_t<T>>;
 };
 
-class TA_ActivityProxy {
+class TA_ActivityProxy : public std::enable_shared_from_this<TA_ActivityProxy> {
     template <typename Ret, typename... Args> using Executor = Ret (*)(Args...);
 
   public:
@@ -105,6 +105,14 @@ class TA_ActivityProxy {
     }
 
     bool isValid() const { return m_pActivity && m_future.valid(); }
+
+    auto sharedRef() -> std::shared_ptr<TA_ActivityProxy> {
+        return this->shared_from_this();
+    }
+
+    auto weakRef() -> std::weak_ptr<TA_ActivityProxy> {
+        return this->weak_from_this();
+    }
 
     TA_DefaultVariant result() const { return m_future.get(); }
 

--- a/ActivityFramework/Src/Components/TA_AutoChainPipeline.cpp
+++ b/ActivityFramework/Src/Components/TA_AutoChainPipeline.cpp
@@ -21,7 +21,7 @@ TA_AutoChainPipeline::TA_AutoChainPipeline() : TA_BasicPipeline() {}
 
 TA_CoroutineGenerator<TA_DefaultVariant, CoreAsync::Eager> runningGenerator(TA_AutoChainPipeline *pPipeline) {
     for (auto i = pPipeline->startIndex(); i < pPipeline->m_pActivityList.size(); ++i) {
-        decltype(auto) pActivity{TA_CommonTools::at<TA_ActivityProxy *>(pPipeline->m_pActivityList, i)};
+        decltype(auto) pActivity{TA_CommonTools::at<std::shared_ptr<TA_ActivityProxy>>(pPipeline->m_pActivityList, i)};
         (*pActivity)();
         auto var{pActivity->result()};
         TA_CommonTools::replace(pPipeline->m_resultList, i, var);

--- a/ActivityFramework/Src/Components/TA_BasicPipeline.cpp
+++ b/ActivityFramework/Src/Components/TA_BasicPipeline.cpp
@@ -28,7 +28,7 @@ bool TA_BasicPipeline::remove(ActivityIndex index) {
     }
     std::lock_guard<std::recursive_mutex> locker(m_mutex);
     if (index < m_pActivityList.size()) {
-        TA_CommonTools::remove<TA_ActivityProxy *>(m_pActivityList, index);
+        TA_CommonTools::remove<std::shared_ptr<TA_ActivityProxy>>(m_pActivityList, index);
         return true;
     }
     return false;
@@ -41,12 +41,6 @@ void TA_BasicPipeline::clear() {
         return;
     }
     m_mutex.lock();
-    for (auto &pActivity : m_pActivityList) {
-        if (pActivity) {
-            delete pActivity;
-            pActivity = nullptr;
-        }
-    }
     m_pActivityList.clear();
     m_resultList.clear();
     m_mutex.unlock();
@@ -56,12 +50,6 @@ void TA_BasicPipeline::clear() {
 
 void TA_BasicPipeline::destroy() {
     m_mutex.lock();
-    for (auto &pActivity : m_pActivityList) {
-        if (pActivity) {
-            delete pActivity;
-            pActivity = nullptr;
-        }
-    }
     m_pActivityList.clear();
     m_resultList.clear();
     if (m_pRunningActivity) {

--- a/ActivityFramework/Src/Components/TA_BasicPipeline.h
+++ b/ActivityFramework/Src/Components/TA_BasicPipeline.h
@@ -146,8 +146,8 @@ class ACTIVITY_FRAMEWORK_EXPORT TA_BasicPipeline : public TA_MetaObject {
         setState(State::Busy);
         std::lock_guard<std::recursive_mutex> locker(m_mutex);
         std::shared_ptr<TA_ActivityExecutingAwaitable> executingAwaitable =
-        std::make_shared<TA_ActivityExecutingAwaitable>(new TA_ActivityProxy(m_pRunningActivity, false),
-                                                        (TA_ActivityExecutingAwaitable::ExecuteType)(type));
+        std::make_shared<TA_ActivityExecutingAwaitable>(
+                std::make_shared<TA_ActivityProxy>(m_pRunningActivity, false), (TA_ActivityExecutingAwaitable::ExecuteType)(type));
         auto fetcher = co_await *executingAwaitable;
         co_return fetcher;
     }
@@ -168,7 +168,7 @@ class ACTIVITY_FRAMEWORK_EXPORT TA_BasicPipeline : public TA_MetaObject {
     void destroy();
 
   protected:
-    std::list<TA_ActivityProxy *> m_pActivityList;
+    std::list<std::shared_ptr<TA_ActivityProxy>> m_pActivityList;
     std::vector<TA_DefaultVariant> m_resultList;
     std::recursive_mutex m_mutex;
     TA_MethodActivity<std::function<void()>> *m_pRunningActivity{nullptr};

--- a/ActivityFramework/Src/Components/TA_ConcurrentPipeline.cpp
+++ b/ActivityFramework/Src/Components/TA_ConcurrentPipeline.cpp
@@ -21,7 +21,7 @@ namespace CoreAsync {
 TA_CoroutineGenerator<TA_DefaultVariant, CoreAsync::Eager> runningGenerator(TA_ConcurrentPipeline *pPipeline) {
     std::vector<TA_ActivityResultFetcher> resultFetchers(pPipeline->m_pActivityList.size());
     for (auto i = pPipeline->startIndex(); i < pPipeline->m_pActivityList.size(); ++i) {
-        decltype(auto) pActivity{TA_CommonTools::at<TA_ActivityProxy *>(pPipeline->m_pActivityList, i)};
+        decltype(auto) pActivity{TA_CommonTools::at<std::shared_ptr<TA_ActivityProxy>>(pPipeline->m_pActivityList, i)};
         std::shared_ptr<TA_ActivityExecutingAwaitable> executingAwaitable =
             std::make_shared<TA_ActivityExecutingAwaitable>(pActivity, TA_ActivityExecutingAwaitable::ExecuteType::Async);
         resultFetchers[i] = co_await *executingAwaitable;
@@ -49,12 +49,6 @@ void TA_ConcurrentPipeline::clear() {
         return;
     }
     m_mutex.lock();
-    for (auto &pActivity : m_pActivityList) {
-        if (pActivity) {
-            delete pActivity;
-            pActivity = nullptr;
-        }
-    }
     m_pActivityList.clear();
     m_resultList.clear();
     m_mutex.unlock();

--- a/ActivityFramework/Src/Components/TA_Connection.h
+++ b/ActivityFramework/Src/Components/TA_Connection.h
@@ -44,7 +44,7 @@ class TA_Connection {
                                                    std::forward<ReceiverFunc>(rFunc));
     }
 
-    static bool disconnect(const TA_MetaObject::TA_ConnectionObjectHolder &pConnection) {
+    static bool disconnect(TA_MetaObject::TA_ConnectionObjectHolder &pConnection) {
         return TA_MetaObject::unregisterConnection(pConnection);
     };
 

--- a/ActivityFramework/Src/Components/TA_Coroutine.h
+++ b/ActivityFramework/Src/Components/TA_Coroutine.h
@@ -32,27 +32,31 @@ template <typename T, CorotuineBehavior = Lazy> struct [[nodiscard]] TA_ManualCo
         std::atomic_bool m_completed{false};
         static constexpr bool isBlockingType{true};
 
+        struct FinalAwaiter {
+            bool await_ready() const noexcept { return false; }
+            void await_suspend(std::coroutine_handle<promise_type> h) noexcept {
+                auto &promise = h.promise();
+                if constexpr (promise_type::isBlockingType) {
+                    promise.m_completed.store(true, std::memory_order_release);
+                    promise.m_completed.notify_all();
+                }
+            }
+            void await_resume() noexcept {}
+        };
+
         TA_ManualCoroutineTask get_return_object() {
             return TA_ManualCoroutineTask{std::coroutine_handle<promise_type>::from_promise(*this)};
         }
 
         std::suspend_always initial_suspend() noexcept { return {}; }
-        std::suspend_always final_suspend() noexcept { return {}; }
+        FinalAwaiter final_suspend() noexcept { return {}; }
 
         void return_value(const T &value) {
             m_result = value;
-            if constexpr(promise_type::isBlockingType) {
-                m_completed.store(true, std::memory_order_release);
-                m_completed.notify_all();
-            }
         }
 
         void unhandled_exception() {
             m_exception = std::current_exception();
-            if constexpr(promise_type::isBlockingType) {
-                m_completed.store(true, std::memory_order_release);
-                m_completed.notify_all();
-            }
         }
     };
 
@@ -113,27 +117,31 @@ template <typename T> struct [[nodiscard]] TA_ManualCoroutineTask<T, Eager> {
         std::atomic_bool m_completed{false};
         static constexpr bool isBlockingType{true};
 
+        struct FinalAwaiter {
+            bool await_ready() const noexcept { return false; }
+            void await_suspend(std::coroutine_handle<promise_type> h) noexcept {
+                auto &promise = h.promise();
+                if constexpr (promise_type::isBlockingType) {
+                    promise.m_completed.store(true, std::memory_order_release);
+                    promise.m_completed.notify_all();
+                }
+            }
+            void await_resume() noexcept {}
+        };
+
         TA_ManualCoroutineTask get_return_object() {
             return TA_ManualCoroutineTask{std::coroutine_handle<promise_type>::from_promise(*this)};
         }
 
         std::suspend_never initial_suspend() noexcept { return {}; }
-        std::suspend_always final_suspend() noexcept { return {}; }
+        FinalAwaiter final_suspend() noexcept { return {}; }
 
         void return_value(const T &value) {
             m_result = value;
-            if constexpr(promise_type::isBlockingType) {
-                m_completed.store(true, std::memory_order_release);
-                m_completed.notify_all();
-            }
         }
 
         void unhandled_exception() {
             m_exception = std::current_exception();
-            if constexpr(promise_type::isBlockingType) {
-                m_completed.store(true, std::memory_order_release);
-                m_completed.notify_all();
-            }
         }
     };
 
@@ -163,6 +171,7 @@ template <typename T> struct [[nodiscard]] TA_ManualCoroutineTask<T, Eager> {
     ~TA_ManualCoroutineTask() {
         if (m_coroutineHandle && !m_coroutineHandle.done()) {
             m_coroutineHandle.destroy();
+            m_coroutineHandle = nullptr;
         }
     }
 

--- a/ActivityFramework/Src/Components/TA_Coroutine.h
+++ b/ActivityFramework/Src/Components/TA_Coroutine.h
@@ -169,7 +169,7 @@ template <typename T> struct [[nodiscard]] TA_ManualCoroutineTask<T, Eager> {
     }
 
     ~TA_ManualCoroutineTask() {
-        if (m_coroutineHandle && !m_coroutineHandle.done()) {
+        if (m_coroutineHandle) {
             m_coroutineHandle.destroy();
             m_coroutineHandle = nullptr;
         }

--- a/ActivityFramework/Src/Components/TA_ManualChainPipeline.cpp
+++ b/ActivityFramework/Src/Components/TA_ManualChainPipeline.cpp
@@ -20,7 +20,7 @@
 namespace CoreAsync {
 TA_CoroutineGenerator<TA_DefaultVariant, CoreAsync::Lazy> runningGenerator(TA_ManualChainPipeline *pPipeline) {
     for (auto i = pPipeline->startIndex(); i < pPipeline->m_pActivityList.size(); ++i) {
-        decltype(auto) pActivity{TA_CommonTools::at<TA_ActivityProxy *>(pPipeline->m_pActivityList, i)};
+        decltype(auto) pActivity{TA_CommonTools::at<std::shared_ptr<TA_ActivityProxy>>(pPipeline->m_pActivityList, i)};
         (*pActivity)();
         auto var{pActivity->result()};
         TA_CommonTools::replace(pPipeline->m_resultList, i, var);
@@ -69,12 +69,6 @@ void TA_ManualChainPipeline::clear() {
         return;
     }
     m_mutex.lock();
-    for (auto &pActivity : m_pActivityList) {
-        if (pActivity) {
-            delete pActivity;
-            pActivity = nullptr;
-        }
-    }
     m_pActivityList.clear();
     m_resultList.clear();
     m_runningGenerator = runningGenerator(this);

--- a/ActivityFramework/Src/Components/TA_ManualKeyActivityChainPipeline.cpp
+++ b/ActivityFramework/Src/Components/TA_ManualKeyActivityChainPipeline.cpp
@@ -22,7 +22,7 @@ TA_CoroutineGenerator<TA_DefaultVariant, CoreAsync::Lazy>
 runningGenerator(TA_ManualKeyActivityChainPipeline *pPipeline) {
     bool isAtKey{false};
     for (auto i = pPipeline->startIndex(); i < pPipeline->m_pActivityList.size();) {
-        decltype(auto) pActivity{TA_CommonTools::at<TA_ActivityProxy *>(pPipeline->m_pActivityList, i)};
+        decltype(auto) pActivity{TA_CommonTools::at<std::shared_ptr<TA_ActivityProxy>>(pPipeline->m_pActivityList, i)};
         if (!pActivity->isExecuted()) {
             (*pActivity)();
             auto var{pActivity->result()};
@@ -93,12 +93,6 @@ void TA_ManualKeyActivityChainPipeline::clear() {
         return;
     }
     m_mutex.lock();
-    for (auto pActivity : m_pActivityList) {
-        if (pActivity) {
-            delete pActivity;
-            pActivity = nullptr;
-        }
-    }
     m_pActivityList.clear();
     m_resultList.clear();
     m_mutex.unlock();

--- a/ActivityFramework/Src/Components/TA_ManualStepsChainPipeline.cpp
+++ b/ActivityFramework/Src/Components/TA_ManualStepsChainPipeline.cpp
@@ -22,7 +22,7 @@ TA_CoroutineGenerator<TA_DefaultVariant, CoreAsync::Lazy> runningGenerator(TA_Ma
     auto step{pPipeline->steps()};
     if (step <= pPipeline->m_pActivityList.size()) {
         for (auto i = pPipeline->startIndex(); i < pPipeline->m_pActivityList.size(); ++i) {
-            decltype(auto) pActivity{TA_CommonTools::at<TA_ActivityProxy *>(pPipeline->m_pActivityList, i)};
+            decltype(auto) pActivity{TA_CommonTools::at<std::shared_ptr<TA_ActivityProxy>>(pPipeline->m_pActivityList, i)};
             (*pActivity)();
             auto var{pActivity->result()};
             TA_CommonTools::replace(pPipeline->m_resultList, i, var);
@@ -74,12 +74,6 @@ void TA_ManualStepsChainPipeline::clear() {
         return;
     }
     m_mutex.lock();
-    for (auto &pActivity : m_pActivityList) {
-        if (pActivity) {
-            delete pActivity;
-            pActivity = nullptr;
-        }
-    }
     m_pActivityList.clear();
     m_resultList.clear();
     m_mutex.unlock();

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -59,6 +59,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         void reset() {
             if (m_pConnection)
                 m_pConnection.reset();
+            m_pConnection = nullptr;
         }
 
       private:
@@ -360,7 +361,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             pReceiver, std::forward<TA_ConnectionObject::FuncMark>(slotMark));
     }
 
-    static bool unregisterConnection(const TA_ConnectionObjectHolder &holder) {
+    static bool unregisterConnection(TA_ConnectionObjectHolder &holder) {
         if (!holder.valid() || !holder.m_pConnection) {
             return false;
         }
@@ -666,7 +667,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     };
 
     template <typename Sender>
-    inline static auto m_unregisterConnectionHolderImpl = [](const TA_ConnectionObjectHolder &holder) -> bool {
+    inline static auto m_unregisterConnectionHolderImpl = [](TA_ConnectionObjectHolder &holder) -> bool {
         if (!holder.valid()) {
             return false;
         }
@@ -687,6 +688,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             }
             startSendIter++;
         }
+        holder.reset();
         return true;
     };
 

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -325,7 +325,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         using ExpType = decltype(m_registerLambdaConnectionImpl<Sender, Signal, LambdaExp>);
         auto registerActivity = TA_ActivityCreator::create(
             std::forward<ExpType>(m_registerLambdaConnectionImpl<Sender, Signal, LambdaExp>),
-            pSender, signal, exp, type, autoDestroy);
+            pSender, std::forward<Signal>(signal), std::forward<LambdaExp>(exp), type, autoDestroy);
         registerActivity->moveToThread(pSender->affinityThread());
         registerActivity->setStolenEnabled(false);
         AsyncTaskRes res = invokeActivity(registerActivity, pSender);

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -98,6 +98,13 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         return *this;
     }
 
+    auto sharedRef() {
+        auto weakRef = this->weak_from_this();
+        if(weakRef.expired())
+            return std::shared_ptr<TA_MetaObject>(this);
+        return weakRef.lock();
+    }
+
     void pendingCountIncrement() {
         m_pendingCounter.increment(); 
     }

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -142,6 +142,10 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         return this->weak_from_this();
     }
 
+    std::shared_ptr<TA_MetaObject> sharedPtr() {
+        return this->shared_from_this(); 
+    }
+
     template <ActivityType Activity>
     [[nodiscard]] inline static AsyncTaskRes invokeActivity(Activity *pActivity, TA_MetaObject *pHost, bool autoDelete = true) {
         if (!pActivity) {

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -583,7 +583,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             auto *pRealSender = resolveSender();
             auto *pRealReceiver = resolveReceiver();
             if(pRealSender && pRealReceiver) {
-                activity->moveToThread(pRealSender->affinityThread());
+                activity->moveToThread(pRealReceiver->affinityThread());
                 if (pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
                     (m_type == TA_ConnectionType::Direct || m_type == TA_ConnectionType::Auto)) {
                     activity->operator()();

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -292,7 +292,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         });
         activity->setStolenEnabled(false);
         activity->moveToThread(this->affinityThread());
-        auto fetcher = TA_ThreadHolder::get().postActivity(activity, false);
+        auto fetcher = TA_ThreadHolder::get().postActivity(activity, true);
         return true;
     }
 

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -111,7 +111,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         auto weakRef = pObject->weak_from_this();
         if(weakRef.expired())
             return std::shared_ptr<std::remove_cvref_t<Object>>(pObject, [](TA_MetaObject *){});
-        return dynamic_pointer_cast<std::remove_cvref_t<Object>>(weakRef.lock());
+        return std::dynamic_pointer_cast<std::remove_cvref_t<Object>>(weakRef.lock());
     }
 
     bool hasSharedRef() {

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -290,7 +290,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             delete this;
         });
         activity->setStolenEnabled(false);
-        invokeActivityNoAwait(activity, this);
+        activity->moveToThread(this->affinityThread());
+        auto fetcher = TA_ThreadHolder::get().postActivity(activity, false);
         return true;
     }
 

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -486,13 +486,22 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         TA_ConnectionObject(Sender *pSender, Signal &&signal, TA_ConnectionType type)
             : m_pSender(pSender),
               m_senderFunc(Reflex::TA_TypeInfo<std::decay_t<Sender>>::findName(std::forward<Signal>(signal))),
-              m_type(type), m_autoDestroy(false) {}
+              m_type(type), m_autoDestroy(false) {
+            if (pSender->hasSharedRef()) {
+                m_wpSender = pSender->weak_from_this();
+            }
+        }
 
         template <EnableConnectObjectType Sender, typename Signal>
         TA_ConnectionObject(Sender *pSender, Signal &&signal, TA_ConnectionType type, bool autoDestroy)
             : m_pSender(pSender), m_pReceiver(pSender),
               m_senderFunc(Reflex::TA_TypeInfo<std::decay_t<Sender>>::findName(std::forward<Signal>(signal))),
-              m_type(type), m_autoDestroy(autoDestroy) {}
+              m_type(type), m_autoDestroy(autoDestroy) {
+            if (pSender->hasSharedRef()) {
+                m_wpSender = pSender->weak_from_this();
+                m_wpReceiver = pSender->weak_from_this();
+            }
+        }
 
         TA_ConnectionObject(const TA_ConnectionObject &object) = delete;
         TA_ConnectionObject(TA_ConnectionObject &&object) = delete;
@@ -514,13 +523,20 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         template <EnableConnectObjectType Receiver, typename Slot>
         void initSlotObject(Receiver *pReceiver, Slot &&slot) {
             m_pReceiver = pReceiver;
+            if (pReceiver->hasSharedRef()) {
+                m_wpReceiver = pReceiver->weak_from_this();
+            }
             m_receiverFunc = Reflex::TA_TypeInfo<std::decay_t<Receiver>>::findName(std::forward<Slot>(slot));
             using SlotParaTuple = typename MethodTypeInfo<Slot>::ArgGroup::Tuple;
             using Ret = typename MethodTypeInfo<Slot>::RetType;
             m_para = SlotParaTuple{};
             auto sharedRef = getSharedPtr();
             SlotExpType slotExp = [sharedRef, slot]() -> void {
-                decltype(auto) rObj{dynamic_cast<std::decay_t<Receiver> *>(sharedRef->m_pReceiver)};
+                auto *pRawReceiver = sharedRef->resolveReceiver();
+                if(!pRawReceiver) {
+                    return;
+                }
+                decltype(auto) rObj{dynamic_cast<std::decay_t<Receiver> *>(pRawReceiver)};
                 if constexpr (IsInstanceMethod<Slot>::value)
                     std::apply(slot, std::move(std::tuple_cat(std::make_tuple(rObj),
                                                               std::any_cast<SlotParaTuple>(sharedRef->m_para))));
@@ -563,14 +579,16 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
 
         void callSlot() {
             if (m_pActivity) {
-                TA_MetaObject *pSender = reinterpret_cast<TA_MetaObject *>(m_pSender);
-                TA_MetaObject *pReceiver = reinterpret_cast<TA_MetaObject *>(m_pReceiver);
-                if (pReceiver->affinityThread() == pSender->affinityThread() &&
-                    (m_type == TA_ConnectionType::Direct || m_type == TA_ConnectionType::Auto)) {
-                    m_pActivity->operator()();
-                } else {
-                    auto fetcher = TA_ThreadHolder::get().postActivity(m_pSlotProxy);
-                    m_pSlotProxy = new TA_ActivityProxy(m_pActivity, false);
+                auto *pRealSender = resolveSender();
+                auto *pRealReceiver = resolveReceiver();
+                if(pRealSender && pRealReceiver) {
+                    if (pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
+                        (m_type == TA_ConnectionType::Direct || m_type == TA_ConnectionType::Auto)) {
+                        m_pActivity->operator()();
+                    } else {
+                        auto fetcher = TA_ThreadHolder::get().postActivity(m_pSlotProxy);
+                        m_pSlotProxy = new TA_ActivityProxy(m_pActivity, false);
+                    }
                 }
             }
             if (m_autoDestroy) {
@@ -579,13 +597,18 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
 
         void removeConnectionReferences() {
+            auto *pRealSender = resolveSender();
+            auto *pRealReceiver = resolveReceiver();
+            if(!pRealSender || !pRealReceiver) {
+                return;
+            }
             m_removeConnectionReferenceImpl<TA_MetaObject, TA_MetaObject>(
-                m_pSender, m_pReceiver,
+                pRealSender, pRealReceiver,
                 std::forward<FuncMark>(m_senderFunc), std::forward<FuncMark>(m_receiverFunc));
         }
 
-        TA_MetaObject *sender() const { return m_pSender; }
-        TA_MetaObject *receiver() const { return m_pReceiver; }
+        TA_MetaObject *sender() const { return resolveSender(); }
+        TA_MetaObject *receiver() const { return resolveReceiver(); }
 
         using FuncMark = std::string_view;
 
@@ -593,14 +616,34 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         const FuncMark &slotMark() const { return m_receiverFunc; }
 
         bool isSync() const {
-            return m_pSender->affinityThread() == m_pReceiver->affinityThread() &&
+            auto *pRealSender = resolveSender();
+            auto *pRealReceiver = resolveReceiver();
+            if (!pRealSender || !pRealReceiver) return false;
+
+            return pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
                    (m_type == TA_ConnectionType::Auto || m_type == TA_ConnectionType::Direct);
         }
 
         bool isAutoDestroy() const { return m_autoDestroy; }
 
       private:
+        TA_MetaObject *resolveSender() const {
+            bool isEmpty = !m_wpSender.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
+                           !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpSender);
+            if (isEmpty) return m_pSender;
+            return m_wpSender.lock().get();
+        }
+
+        TA_MetaObject *resolveReceiver() const {
+            bool isEmpty = !m_wpReceiver.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
+                           !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpReceiver);
+            if (isEmpty) return m_pReceiver;
+            return m_wpReceiver.lock().get();
+        }
+
+      private:
         TA_MetaObject *m_pSender{nullptr}, *m_pReceiver{nullptr};
+        std::weak_ptr<TA_MetaObject> m_wpSender{}, m_wpReceiver{};
         FuncMark m_senderFunc{}, m_receiverFunc{};
         TA_ConnectionType m_type;
         std::any m_para;

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -128,7 +128,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     }
 
     bool isIdle() const {
-        return m_pendingCounter.isIdle() && !m_isBeingDestroyed.load(std::memory_order_acquire);;
+        return m_pendingCounter.isIdle() && !m_isBeingDestroyed.load(std::memory_order_acquire);
     }
 
     void resetPendingCount() {

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -192,9 +192,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             idx = pHost->affinityThread();
         }
         pActivity->moveToThread(idx);
-        TA_ActivityProxy *proxy = new TA_ActivityProxy(pActivity, autoDelete);
         std::shared_ptr<TA_ActivityFetcherAwaitable> fetcherAwaitable =
-            std::make_shared<TA_ActivityFetcherAwaitable>(proxy);
+            std::make_shared<TA_ActivityFetcherAwaitable>(std::make_shared<TA_ActivityProxy>(pActivity, autoDelete));
         auto res = co_await *fetcherAwaitable;
         pHost->pendingCountDecrement();
         co_return res;

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -127,11 +127,15 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     }
 
     bool isIdle() const {
-        return m_pendingCounter.isIdle();
+        return m_pendingCounter.isIdle() && !m_isBeingDestroyed.load(std::memory_order_acquire);;
     }
 
     void resetPendingCount() {
         m_pendingCounter.reset();
+    }
+
+    bool isBeingDestroyed() const {
+        return m_isBeingDestroyed.load(std::memory_order_acquire);
     }
 
   protected:
@@ -175,6 +179,9 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if (!pHost) {
             throw std::invalid_argument("Host object is null");
         }
+        if (pHost->isBeingDestroyed()) {
+            throw std::runtime_error("Host object is being destroyed.");
+        }
         pHost->pendingCountIncrement();
         std::size_t idx = pHost->affinityThread();
         if (idx >= TA_ThreadHolder::get().size()) {
@@ -200,6 +207,9 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
         if (!pHost) {
             throw std::invalid_argument("Host object is null");
+        }
+        if (pHost->isBeingDestroyed()) {
+            throw std::runtime_error("Host object is being destroyed.");
         }
         pHost->pendingCountIncrement();
         std::size_t idx = pHost->affinityThread();
@@ -273,8 +283,16 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             TA_ActivityCreator::create(Method{}, std::forward<Args>(args)...), true);
     }
 
-    void deleteLater() {
-        invokeMethod([this]() { delete this; });
+    bool deleteLater() {
+        if(hasSharedRef())
+            return false;
+        m_isBeingDestroyed.store(true, std::memory_order_release);
+        auto activity = TA_ActivityCreator::create([this]() -> void {
+            delete this;
+        });
+        activity->setStolenEnabled(false);
+        invokeActivityNoAwait(activity, this);
+        return true;
     }
 
     std::size_t affinityThread() const { return m_affinityThreadIdx.load(std::memory_order_acquire); }
@@ -690,6 +708,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     const std::thread::id m_sourceThread;
     std::atomic_size_t m_affinityThreadIdx;
     PendingCounter m_pendingCounter {};
+    std::atomic_bool m_isBeingDestroyed{false};
 
     std::unordered_multimap<TA_ConnectionObject::FuncMark, std::shared_ptr<TA_ConnectionObject>> m_outputConnections{};
     std::unordered_multimap<TA_ConnectionObject::FuncMark, std::shared_ptr<TA_ConnectionObject>> m_inputConnections{};

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -39,6 +39,9 @@ concept EnableConnectObjectType = requires(T *t) {
     { t } -> std::convertible_to<TA_MetaObject *>;
 };
 
+template <typename T>
+concept ConnectionParameter = std::copy_constructible<T> && std::is_trivially_copyable_v<T>;
+
 template <typename T> struct TA_MetaObjectTraits {
     static constexpr bool isMetaObject = std::is_base_of_v<CoreAsync::TA_MetaObject, T>;
 };
@@ -424,8 +427,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         return taskResult->template get<bool>();
     }
 
-    template <EnableConnectObjectType Sender, typename Signal, typename... Args>
-    static constexpr bool emitSignal(Sender *pSender, Signal &&signal, Args &&...args) {
+    template <EnableConnectObjectType Sender, typename Signal, typename... ConnectionParameter>
+    static constexpr bool emitSignal(Sender *pSender, Signal &&signal, ConnectionParameter &&...args) {
         if constexpr (!Reflex::TA_MemberTypeTrait<Signal>::instanceMethodFlag ||
                       !IsReturnTypeEqual<void, Signal, std::is_same>::value) {
             static_assert(false, "The signal must be an instance method and return void.");
@@ -433,25 +436,27 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if constexpr (!std::is_convertible_v<std::decay_t<Sender *>, typename MethodTypeInfo<Signal>::ParentClass *>) {
             static_assert(false, "The signal must belong to the sender class.");
         }
+        static_assert((std::is_copy_constructible_v<std::remove_cvref_t<ConnectionParameter>> && ...),
+                      "Signal arguments must be copy-constructible.");
         if (!pSender) {
             return false;
         }
         if(isOnCurrentThread(pSender)) {
-            m_emitSignalImpl<Sender *, Signal, Args...>(pSender, std::forward<Signal>(signal), std::forward<Args>(args)...);
+            m_emitSignalImpl<Sender *, Signal, std::remove_cvref_t<ConnectionParameter>...>(pSender, std::forward<Signal>(signal), std::forward<ConnectionParameter>(args)...);
         } else {
             if(!pSender->hasSharedRef()) {
-                using RawPtrExpType = decltype(m_emitSignalImpl<Sender *, Signal, Args...>);
+                using RawPtrExpType = decltype(m_emitSignalImpl<Sender *, Signal, std::remove_cvref_t<ConnectionParameter>...>);
                 auto activity = TA_ActivityCreator::create(
-                    std::forward<RawPtrExpType>(m_emitSignalImpl<Sender *, Signal, Args...>),
-                    pSender, std::forward<Signal>(signal), std::forward<Args>(args)...);
+                    std::forward<RawPtrExpType>(m_emitSignalImpl<Sender *, Signal, std::remove_cvref_t<ConnectionParameter>...>),
+                    pSender, std::forward<Signal>(signal), std::forward<ConnectionParameter>(args)...);
                 activity->setStolenEnabled(false);
                 invokeActivityNoAwait(activity, pSender);
             } else {
                 auto sharedSender = sharedRef(pSender);
-                using SharedExpType = decltype(m_emitSignalImpl<std::shared_ptr<Sender>, Signal, Args...>);
+                using SharedExpType = decltype(m_emitSignalImpl<std::shared_ptr<Sender>, Signal, std::remove_cvref_t<ConnectionParameter>...>);
                 auto activity = TA_ActivityCreator::create(
-                    std::forward<SharedExpType>(m_emitSignalImpl<std::shared_ptr<Sender>, Signal, Args...>),
-                    std::move(sharedSender), std::forward<Signal>(signal), std::forward<Args>(args)...);
+                    std::forward<SharedExpType>(m_emitSignalImpl<std::shared_ptr<Sender>, Signal, std::remove_cvref_t<ConnectionParameter>...>),
+                    std::move(sharedSender), std::forward<Signal>(signal), std::forward<ConnectionParameter>(args)...);
                 activity->setStolenEnabled(false);
                 invokeActivityNoAwait(activity, pSender);
             }
@@ -629,7 +634,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
       private:
         //Users need to ensure the validity of the returned pointer and check for nullptr before use.
         TA_MetaObject *resolveSender() const {
-            bool isEmpty = !m_wpSender.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
+            bool isEmpty = !m_wpSender.owner_before(std::weak_ptr<TA_MetaObject>{}) &&
                            !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpSender);
             if (isEmpty) return m_pSender;
             return m_wpSender.lock().get();
@@ -637,7 +642,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
 
         //Users need to ensure the validity of the returned pointer and check for nullptr before use.
         TA_MetaObject *resolveReceiver() const {
-            bool isEmpty = !m_wpReceiver.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
+            bool isEmpty = !m_wpReceiver.owner_before(std::weak_ptr<TA_MetaObject>{}) &&
                            !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpReceiver);
             if (isEmpty) return m_pReceiver;
             return m_wpReceiver.lock().get();
@@ -730,7 +735,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             if(startIter != endIter) {
                 obj->setPara(args...);
             } else {
-                obj->setPara(std::forward<Args>(args)...);
+                obj->setPara(std::move(args)...);
             }
             obj->callSlot();
         }

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -667,7 +667,11 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             Reflex::TA_TypeInfo<RawType>::findName(std::forward<Signal>(signal)));
         while (startIter != endIter) {
             auto obj = startIter++->second;
-            obj->setPara(std::forward<Args>(args)...);
+            if(startIter != endIter) {
+                obj->setPara(args...);
+            } else {
+                obj->setPara(std::forward<Args>(args)...);
+            }
             obj->callSlot();
         }
     };

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -377,13 +377,15 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if (!pSender || !pReceiver) {
             return false;
         }
+        auto sharedSender = sharedRef(pSender);
+        auto sharedReceiver = sharedRef(pReceiver);
         TA_ConnectionObject::FuncMark signalMark{
             Reflex::TA_TypeInfo<std::decay_t<Sender>>::findName(std::forward<Signal>(signal))};
         TA_ConnectionObject::FuncMark slotMark{
             Reflex::TA_TypeInfo<std::decay_t<Receiver>>::findName(std::forward<Slot>(slot))};
-        return m_unregisterConnectionImpl<Sender, Receiver>(
-            pSender, std::forward<TA_ConnectionObject::FuncMark>(signalMark),
-            pReceiver, std::forward<TA_ConnectionObject::FuncMark>(slotMark));
+        return m_unregisterConnectionImpl<std::shared_ptr<Sender>, std::shared_ptr<Receiver>>(
+            sharedSender, std::forward<TA_ConnectionObject::FuncMark>(signalMark),
+            sharedReceiver, std::forward<TA_ConnectionObject::FuncMark>(slotMark));
     }
 
     static bool unregisterConnection(TA_ConnectionObjectHolder &holder) {
@@ -707,16 +709,16 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         return true;
     };
 
-    template <typename Sender, typename Receiver>
-    inline static auto m_unregisterConnectionImpl = [](Sender *pSender, TA_ConnectionObject::FuncMark &&signal,
-                                                        Receiver *pReceiver, TA_ConnectionObject::FuncMark &&slot) -> bool {
+    template <SmartPtrType Sender, SmartPtrType Receiver>
+    inline static auto m_unregisterConnectionImpl = [](Sender pSender, TA_ConnectionObject::FuncMark &&signal,
+                                                        Receiver pReceiver, TA_ConnectionObject::FuncMark &&slot) -> bool {
         std::shared_ptr<TA_ConnectionObject> pConnection{nullptr};
         auto senderUnregisterExp = [&pConnection, pSender, signal, pReceiver, slot]() ->bool {
             auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signal);
             if (startSendIter == endSendIter)
                 return false;
             while (startSendIter != endSendIter) {
-                if (startSendIter->second->receiver() == pReceiver &&
+                if (startSendIter->second->receiver() == pReceiver.get() &&
                     startSendIter->second->slotMark() == slot) {
                     pConnection = startSendIter->second;
                     pSender->m_outputConnections.erase(startSendIter);
@@ -760,7 +762,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
         auto receiverActivity = TA_ActivityCreator::create(std::move(receiverUnregisterExp));
         receiverActivity->setStolenEnabled(false);
-        AsyncTaskRes res = invokeActivity(receiverActivity, pReceiver);
+        AsyncTaskRes res = invokeActivity(receiverActivity, pReceiver.get());
         auto taskResult = res.get();
         return taskResult->template get<bool>();
     };

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -59,7 +59,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         TA_ConnectionObjectHolder(const std::shared_ptr<TA_ConnectionObject> &pConnection)
             : m_pConnection(pConnection ? pConnection->getSharedPtr() : nullptr) {}
 
-        ~TA_ConnectionObjectHolder() {}
+        ~TA_ConnectionObjectHolder() = default;
 
         bool valid() const { return m_pConnection != nullptr; }
 
@@ -416,7 +416,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
         using ExpType = decltype(m_unregisterConnectionHolderImpl<TA_MetaObject>);
         auto activity = TA_ActivityCreator::create(
-            std::forward<ExpType>(m_unregisterConnectionHolderImpl<TA_MetaObject>), holder);
+            std::forward<ExpType>(m_unregisterConnectionHolderImpl<TA_MetaObject>), std::forward<TA_ConnectionObjectHolder>(holder));
         activity->setStolenEnabled(false);
         AsyncTaskRes res = invokeActivity(activity, pSender);
         auto taskResult = res.get();

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -21,6 +21,7 @@
 #include <thread>
 #include <unordered_map>
 #include <any>
+#include <functional>
 
 #include "TA_ThreadPool.h"
 #include "TA_MetaReflex.h"
@@ -416,7 +417,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
         using ExpType = decltype(m_unregisterConnectionHolderImpl<TA_MetaObject>);
         auto activity = TA_ActivityCreator::create(
-            std::forward<ExpType>(m_unregisterConnectionHolderImpl<TA_MetaObject>), std::forward<TA_ConnectionObjectHolder>(holder));
+            std::forward<ExpType>(m_unregisterConnectionHolderImpl<TA_MetaObject>), std::ref(holder));
         activity->setStolenEnabled(false);
         AsyncTaskRes res = invokeActivity(activity, pSender);
         auto taskResult = res.get();

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -315,9 +315,11 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if (!pSender || !pReceiver) {
             return false;
         }
-        return m_registerConnectionImpl<Sender, Signal, Receiver, Slot>(
-            pSender, std::forward<Signal>(signal),
-            pReceiver, std::forward<Slot>(slot), type);
+        auto sharedSender = sharedRef(pSender);
+        auto sharedReceiver = sharedRef(pReceiver);
+        return m_registerConnectionImpl<std::shared_ptr<Sender>, Signal, std::shared_ptr<Receiver>, Slot>(
+            sharedSender, std::forward<Signal>(signal),
+            sharedReceiver, std::forward<Slot>(slot), type);
     }
 
     template <EnableConnectObjectType Sender, typename Signal, LambdaExpType LambdaExp>
@@ -784,28 +786,30 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         return {conn};
     };
 
-    template <typename Sender, typename Signal, typename Receiver, typename Slot>
-    inline static auto m_registerConnectionImpl = [](Sender *pSender, Signal &&signal,
-                                                     Receiver *pReceiver, Slot &&slot,
+    template <SmartPtrType Sender, typename Signal, SmartPtrType Receiver, typename Slot>
+    inline static auto m_registerConnectionImpl = [](Sender pSender, Signal &&signal,
+                                                     Receiver pReceiver, Slot &&slot,
                                                      TA_ConnectionType type) -> bool {
         using SharedConnection = std::shared_ptr<TA_ConnectionObject>;
+        using RawSenderType = typename ExtractRawType<Sender>::type;
+        using RawReceiverType = typename ExtractRawType<Receiver>::type;
         TA_ConnectionObject::FuncMark slotMark {
-            Reflex::TA_TypeInfo<std::decay_t<Receiver>>::findName(std::forward<Slot>(slot))};
+            Reflex::TA_TypeInfo<std::decay_t<RawReceiverType>>::findName(std::forward<Slot>(slot))};
         if(pSender->affinityThread() == pReceiver->affinityThread()) {
             auto syncRegisterExp = [pSender, &signal, pReceiver, &slot, type, slotMark]() -> bool {
                 TA_ConnectionObject::FuncMark signalMark{
-                    Reflex::TA_TypeInfo<std::decay_t<Sender>>::findName(std::forward<Signal>(signal))};
+                    Reflex::TA_TypeInfo<std::decay_t<RawSenderType>>::findName(std::forward<Signal>(signal))};
                 auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
                 while (startSendIter != endSendIter) {
-                    if (startSendIter->second->receiver() == pReceiver &&
+                    if (startSendIter->second->receiver() == pReceiver.get() &&
                         startSendIter->second->slotMark() == slotMark) {
                         return false;
                     }
                     startSendIter++;
                 }
 
-                auto &&conn = std::make_shared<TA_ConnectionObject>(pSender, std::move(signal), type);
-                conn->initSlotObject(pReceiver, std::forward<Slot>(slot));
+                auto &&conn = std::make_shared<TA_ConnectionObject>(pSender.get(), std::move(signal), type);
+                conn->initSlotObject(pReceiver.get(), std::forward<Slot>(slot));
                 pSender->m_outputConnections.emplace(signalMark, conn->getSharedPtr());
                 pReceiver->m_inputConnections.emplace(slotMark, conn->getSharedPtr());
                 return true;
@@ -815,25 +819,25 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             } else {
                 auto syncActivity = TA_ActivityCreator::create(std::move(syncRegisterExp));
                 syncActivity->setStolenEnabled(false);
-                AsyncTaskRes res = invokeActivity(syncActivity, pSender);
+                AsyncTaskRes res = invokeActivity(syncActivity, pSender.get());
                 auto taskResult = res.get();
                 return taskResult->template get<bool>();
             }
         } else {
             auto senderRegisterExp = [pSender, &signal, pReceiver, &slot, type, &slotMark]() -> SharedConnection {
                 TA_ConnectionObject::FuncMark signalMark{
-                    Reflex::TA_TypeInfo<std::decay_t<Sender>>::findName(std::forward<Signal>(signal))};
+                    Reflex::TA_TypeInfo<std::decay_t<RawSenderType>>::findName(std::forward<Signal>(signal))};
                 auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
                 while (startSendIter != endSendIter) {
-                    if (startSendIter->second->receiver() == pReceiver &&
+                    if (startSendIter->second->receiver() == pReceiver.get() &&
                         startSendIter->second->slotMark() == slotMark) {
                         return nullptr;
                     }
                     startSendIter++;
                 }
 
-                auto &&conn = std::make_shared<TA_ConnectionObject>(pSender, std::move(signal), type);
-                conn->initSlotObject(pReceiver, std::forward<Slot>(slot));
+                auto &&conn = std::make_shared<TA_ConnectionObject>(pSender.get(), std::move(signal), type);
+                conn->initSlotObject(pReceiver.get(), std::forward<Slot>(slot));
                 pSender->m_outputConnections.emplace(signalMark, conn->getSharedPtr());
                 return conn;
             };
@@ -843,7 +847,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             } else {
                 auto senderRegisterActivity = TA_ActivityCreator::create(std::move(senderRegisterExp));
                 senderRegisterActivity->setStolenEnabled(false);
-                AsyncTaskRes res = invokeActivity(senderRegisterActivity, pSender);
+                AsyncTaskRes res = invokeActivity(senderRegisterActivity, pSender.get());
                 auto taskResult = res.get();
                 connectionObj = taskResult->template get<SharedConnection>();
 
@@ -859,7 +863,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             } else {
                 auto addIntoReceiverActivity = TA_ActivityCreator::create(std::move(receiverRegisterExp));
                 addIntoReceiverActivity->setStolenEnabled(false);
-                AsyncTaskRes res = invokeActivity(addIntoReceiverActivity, pReceiver);
+                AsyncTaskRes res = invokeActivity(addIntoReceiverActivity, pReceiver.get());
                 auto taskResult = res.get();
             }
             return true;

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -341,14 +341,16 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if constexpr (MethodTypeInfo<Signal>::argSize != LambdaExpTraits<std::decay_t<LambdaExp>>::argSize) {
             return {nullptr};
         }
+
+        auto sharedSender = sharedRef(pSender);
         if(isOnCurrentThread(pSender)) {
-            return m_registerLambdaConnectionImpl<Sender, Signal, LambdaExp>(
-                pSender, std::forward<Signal>(signal), std::forward<LambdaExp>(exp), type, autoDestroy);
+            return m_registerLambdaConnectionImpl<std::shared_ptr<Sender>, Signal, LambdaExp>(
+                sharedSender, std::forward<Signal>(signal), std::forward<LambdaExp>(exp), type, autoDestroy);
         }
-        using ExpType = decltype(m_registerLambdaConnectionImpl<Sender, Signal, LambdaExp>);
+        using ExpType = decltype(m_registerLambdaConnectionImpl<std::shared_ptr<Sender>, Signal, LambdaExp>);
         auto registerActivity = TA_ActivityCreator::create(
-            std::forward<ExpType>(m_registerLambdaConnectionImpl<Sender, Signal, LambdaExp>),
-            pSender, std::forward<Signal>(signal), std::forward<LambdaExp>(exp), type, autoDestroy);
+            std::forward<ExpType>(m_registerLambdaConnectionImpl<std::shared_ptr<Sender>, Signal, LambdaExp>),
+            sharedSender, std::forward<Signal>(signal), std::forward<LambdaExp>(exp), type, autoDestroy);
         registerActivity->moveToThread(pSender->affinityThread());
         registerActivity->setStolenEnabled(false);
         AsyncTaskRes res = invokeActivity(registerActivity, pSender);
@@ -763,22 +765,23 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         return taskResult->template get<bool>();
     };
 
-    template <typename Sender, typename Signal, LambdaExpType Exp>
-    inline static auto m_registerLambdaConnectionImpl = [](Sender *pSender, Signal signal,
+    template <SmartPtrType Sender, typename Signal, LambdaExpType Exp>
+    inline static auto m_registerLambdaConnectionImpl = [](Sender pSender, Signal signal,
                                                            Exp exp, TA_ConnectionType type,
                                                            bool autoDestroy) -> TA_ConnectionObjectHolder {
+        using RawSenderType = typename ExtractRawType<Sender>::type;
         TA_ConnectionObject::FuncMark signalMark{
-            Reflex::TA_TypeInfo<std::decay_t<Sender>>::findName(std::forward<Signal>(signal))};
+            Reflex::TA_TypeInfo<std::decay_t<RawSenderType>>::findName(std::forward<Signal>(signal))};
         TA_ConnectionObject::FuncMark slotMark{typeid(Exp).name()};
         auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
         while (startSendIter != endSendIter) {
-            if (startSendIter->second->receiver() == pSender && startSendIter->second->slotMark() == slotMark) {
+            if (startSendIter->second->receiver() == pSender.get() && startSendIter->second->slotMark() == slotMark) {
                 return {nullptr};
             }
             startSendIter++;
         }
 
-        auto &&conn = std::make_shared<TA_ConnectionObject>(pSender, std::move(signal), type, autoDestroy);
+        auto &&conn = std::make_shared<TA_ConnectionObject>(pSender.get(), std::move(signal), type, autoDestroy);
         conn->initSlotObject(std::move(exp));
         pSender->m_outputConnections.emplace(signalMark, conn->getSharedPtr());
         if (autoDestroy)

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -583,7 +583,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
 
         void callSlot() {
-            auto activity = TA_ActivityCreator::create(std::forward<SlotExpType>(m_slotExp));
+            auto slotExp = m_slotExp;
+            auto activity = TA_ActivityCreator::create(std::forward<SlotExpType>(slotExp));
             activity->setStolenEnabled(false);
             auto *pRealSender = resolveSender();
             auto *pRealReceiver = resolveReceiver();

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -411,7 +411,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if (!holder.valid() || !holder.m_pConnection) {
             return false;
         }
-        auto *pSender = holder.m_pConnection->sender();
+        auto pSender = holder.m_pConnection->sender();
         if(isOnCurrentThread(pSender)) {
             return m_unregisterConnectionHolderImpl<TA_MetaObject>(holder);
         }
@@ -419,7 +419,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         auto activity = TA_ActivityCreator::create(
             std::forward<ExpType>(m_unregisterConnectionHolderImpl<TA_MetaObject>), std::ref(holder));
         activity->setStolenEnabled(false);
-        AsyncTaskRes res = invokeActivity(activity, pSender);
+        AsyncTaskRes res = invokeActivity(activity, pSender.get());
         auto taskResult = res.get();
         return taskResult->template get<bool>();
     }
@@ -545,11 +545,11 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             m_para = SlotParaTuple{};
             auto sharedRef = getSharedPtr();
             m_slotExp = [sharedRef, slot]() -> void {
-                auto *pRawReceiver = sharedRef->resolveReceiver();
+                auto pRawReceiver = sharedRef->resolveReceiver();
                 if(!pRawReceiver) {
                     return;
                 }
-                decltype(auto) rObj{dynamic_cast<std::decay_t<Receiver> *>(pRawReceiver)};
+                decltype(auto) rObj{dynamic_cast<std::decay_t<Receiver> *>(pRawReceiver.get())};
                 if constexpr (IsInstanceMethod<Slot>::value)
                     std::apply(slot, std::move(std::tuple_cat(std::make_tuple(rObj),
                                                               std::any_cast<SlotParaTuple>(sharedRef->m_para))));
@@ -580,8 +580,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         void callSlot() {
             auto activity = TA_ActivityCreator::create(std::forward<SlotExpType>(m_slotExp));
             activity->setStolenEnabled(false);
-            auto *pRealSender = resolveSender();
-            auto *pRealReceiver = resolveReceiver();
+            auto pRealSender = resolveSender();
+            auto pRealReceiver = resolveReceiver();
             if(pRealSender && pRealReceiver) {
                 activity->moveToThread(pRealSender->affinityThread());
                 if (pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
@@ -597,18 +597,18 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
 
         void removeConnectionReferences() {
-            auto *pRealSender = resolveSender();
-            auto *pRealReceiver = resolveReceiver();
+            auto pRealSender = resolveSender();
+            auto pRealReceiver = resolveReceiver();
             if(!pRealSender || !pRealReceiver) {
                 return;
             }
             m_removeConnectionReferenceImpl<TA_MetaObject, TA_MetaObject>(
-                pRealSender, pRealReceiver,
+                pRealSender.get(), pRealReceiver.get(),
                 std::forward<FuncMark>(m_senderFunc), std::forward<FuncMark>(m_receiverFunc));
         }
 
-        TA_MetaObject *sender() const { return resolveSender(); }
-        TA_MetaObject *receiver() const { return resolveReceiver(); }
+        std::shared_ptr<TA_MetaObject> sender() const { return resolveSender(); }
+        std::shared_ptr<TA_MetaObject> receiver() const { return resolveReceiver(); }
 
         using FuncMark = std::string_view;
 
@@ -616,8 +616,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         const FuncMark &slotMark() const { return m_receiverFunc; }
 
         bool isSync() const {
-            auto *pRealSender = resolveSender();
-            auto *pRealReceiver = resolveReceiver();
+            auto pRealSender = resolveSender();
+            auto pRealReceiver = resolveReceiver();
             if (!pRealSender || !pRealReceiver) return false;
 
             return pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
@@ -628,19 +628,21 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
 
       private:
         //Users need to ensure the validity of the returned pointer and check for nullptr before use.
-        TA_MetaObject *resolveSender() const {
+        std::shared_ptr<TA_MetaObject> resolveSender() const {
             bool isEmpty = !m_wpSender.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
                            !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpSender);
-            if (isEmpty) return m_pSender;
-            return m_wpSender.lock().get();
+            if (isEmpty)
+                return std::shared_ptr<TA_MetaObject>{(std::make_shared<TA_MetaObject>()), m_pSender};
+            return m_wpSender.lock();
         }
 
         //Users need to ensure the validity of the returned pointer and check for nullptr before use.
-        TA_MetaObject *resolveReceiver() const {
+        std::shared_ptr<TA_MetaObject> resolveReceiver() const {
             bool isEmpty = !m_wpReceiver.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
                            !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpReceiver);
-            if (isEmpty) return m_pReceiver;
-            return m_wpReceiver.lock().get();
+            if (isEmpty) 
+                return std::shared_ptr<TA_MetaObject>(std::make_shared<TA_MetaObject>(), m_pReceiver);
+            return m_wpReceiver.lock();
         }
 
       private:
@@ -708,7 +710,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
            Receiver pReceiver, TA_ConnectionObject::FuncMark &&slot) -> bool {
         auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signal);
         while (startSendIter != endSendIter) {
-            if (startSendIter->second->receiver() == pReceiver.get() &&
+            if (startSendIter->second->receiver().get() == pReceiver.get() &&
                 startSendIter->second->slotMark() == slot) {
                 return true;
             }
@@ -745,7 +747,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if (!pConnection) {
             return false;
         }
-        Sender *pSender = pConnection->sender();
+        auto pSender = pConnection->sender();
         if(pSender) {
             auto &&signalMark = pConnection->signalMark();
             auto &&slotMark = pConnection->slotMark();
@@ -773,7 +775,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             if (startSendIter == endSendIter)
                 return false;
             while (startSendIter != endSendIter) {
-                if (startSendIter->second->receiver() == pReceiver.get() &&
+                if (startSendIter->second->receiver().get() == pReceiver.get() &&
                     startSendIter->second->slotMark() == slot) {
                     pConnection = startSendIter->second;
                     pSender->m_outputConnections.erase(startSendIter);
@@ -832,7 +834,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         TA_ConnectionObject::FuncMark slotMark{typeid(Exp).name()};
         auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
         while (startSendIter != endSendIter) {
-            if (startSendIter->second->receiver() == pSender.get() && startSendIter->second->slotMark() == slotMark) {
+            if (startSendIter->second->receiver().get() == pSender.get() && startSendIter->second->slotMark() == slotMark) {
                 return {nullptr};
             }
             startSendIter++;
@@ -861,7 +863,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
                     Reflex::TA_TypeInfo<std::decay_t<RawSenderType>>::findName(std::forward<Signal>(signal))};
                 auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
                 while (startSendIter != endSendIter) {
-                    if (startSendIter->second->receiver() == pReceiver.get() &&
+                    if (startSendIter->second->receiver().get() == pReceiver.get() &&
                         startSendIter->second->slotMark() == slotMark) {
                         return false;
                     }
@@ -889,7 +891,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
                     Reflex::TA_TypeInfo<std::decay_t<RawSenderType>>::findName(std::forward<Signal>(signal))};
                 auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
                 while (startSendIter != endSendIter) {
-                    if (startSendIter->second->receiver() == pReceiver.get() &&
+                    if (startSendIter->second->receiver().get() == pReceiver.get() &&
                         startSendIter->second->slotMark() == slotMark) {
                         return nullptr;
                     }
@@ -947,7 +949,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             [](Sender *pSender, TA_ConnectionObject::FuncMark &&signal) -> void {
             auto rangeSender = pSender->m_outputConnections.equal_range(signal);
             for (auto iter = rangeSender.first; iter != rangeSender.second; ++iter) {
-                if (iter->second->sender() == pSender) {
+                if (iter->second->sender().get() == pSender) {
                     pSender->m_outputConnections.erase(iter);
                     break;
                 }
@@ -960,7 +962,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         auto receiverExp = [pReceiver, &slot]() -> void {
             auto rangeReceiver = pReceiver->m_inputConnections.equal_range(slot);
             for (auto iter = rangeReceiver.first; iter != rangeReceiver.second; ++iter) {
-                if (iter->second->receiver() == pReceiver) {
+                if (iter->second->receiver().get() == pReceiver) {
                     pReceiver->m_inputConnections.erase(iter);
                     break;
                 }

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -464,13 +464,16 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             Reflex::TA_TypeInfo<std::decay_t<Sender>>::findName(std::forward<Signal>(signal))};
         TA_ConnectionObject::FuncMark slotMark{
             Reflex::TA_TypeInfo<std::decay_t<Receiver>>::findName(std::forward<Slot>(slot))};
+        auto sharedSender = sharedRef(pSender);
+        auto sharedReceiver = sharedRef(pReceiver);
         if(isOnCurrentThread(pSender)) {
-            return m_isConnectionExistedImpl<Sender, Receiver>(
-                pSender, std::forward<TA_ConnectionObject::FuncMark>(signalMark),
-                pReceiver, std::forward<TA_ConnectionObject::FuncMark>(slotMark));
+            return m_isConnectionExistedImpl<std::shared_ptr<Sender>, std::shared_ptr<Receiver>>(
+                sharedSender, std::forward<TA_ConnectionObject::FuncMark>(signalMark),
+                sharedReceiver, std::forward<TA_ConnectionObject::FuncMark>(slotMark));
         }
-        auto activity = TA_ActivityCreator::create(m_isConnectionExistedImpl<Sender, Receiver>,
-                                                   pSender, signalMark, pReceiver, slotMark);
+        auto activity = TA_ActivityCreator::create(
+            m_isConnectionExistedImpl<std::shared_ptr<Sender>, std::shared_ptr<Receiver>>,
+            sharedSender, signalMark, sharedReceiver, slotMark);
         activity->setStolenEnabled(false);
         AsyncTaskRes res = invokeActivity(activity, pSender);
         auto taskResult = res.get();
@@ -692,13 +695,13 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     std::unordered_multimap<TA_ConnectionObject::FuncMark, std::shared_ptr<TA_ConnectionObject>> m_inputConnections{};
 
   private:
-    template <typename Sender, typename Receiver>
+    template <SmartPtrType Sender, SmartPtrType Receiver>
     inline static auto m_isConnectionExistedImpl =
-        [](Sender *pSender, TA_ConnectionObject::FuncMark &&signal,
-           Receiver *pReceiver, TA_ConnectionObject::FuncMark &&slot) -> bool {
+        [](Sender pSender, TA_ConnectionObject::FuncMark &&signal,
+           Receiver pReceiver, TA_ConnectionObject::FuncMark &&slot) -> bool {
         auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signal);
         while (startSendIter != endSendIter) {
-            if (startSendIter->second->receiver() == pReceiver &&
+            if (startSendIter->second->receiver() == pReceiver.get() &&
                 startSendIter->second->slotMark() == slot) {
                 return true;
             }

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -411,7 +411,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if (!holder.valid() || !holder.m_pConnection) {
             return false;
         }
-        auto pSender = holder.m_pConnection->sender();
+        auto *pSender = holder.m_pConnection->sender();
         if(isOnCurrentThread(pSender)) {
             return m_unregisterConnectionHolderImpl<TA_MetaObject>(holder);
         }
@@ -419,7 +419,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         auto activity = TA_ActivityCreator::create(
             std::forward<ExpType>(m_unregisterConnectionHolderImpl<TA_MetaObject>), std::ref(holder));
         activity->setStolenEnabled(false);
-        AsyncTaskRes res = invokeActivity(activity, pSender.get());
+        AsyncTaskRes res = invokeActivity(activity, pSender);
         auto taskResult = res.get();
         return taskResult->template get<bool>();
     }
@@ -545,11 +545,11 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             m_para = SlotParaTuple{};
             auto sharedRef = getSharedPtr();
             m_slotExp = [sharedRef, slot]() -> void {
-                auto pRawReceiver = sharedRef->resolveReceiver();
+                auto *pRawReceiver = sharedRef->resolveReceiver();
                 if(!pRawReceiver) {
                     return;
                 }
-                decltype(auto) rObj{dynamic_cast<std::decay_t<Receiver> *>(pRawReceiver.get())};
+                decltype(auto) rObj{dynamic_cast<std::decay_t<Receiver> *>(pRawReceiver)};
                 if constexpr (IsInstanceMethod<Slot>::value)
                     std::apply(slot, std::move(std::tuple_cat(std::make_tuple(rObj),
                                                               std::any_cast<SlotParaTuple>(sharedRef->m_para))));
@@ -580,8 +580,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         void callSlot() {
             auto activity = TA_ActivityCreator::create(std::forward<SlotExpType>(m_slotExp));
             activity->setStolenEnabled(false);
-            auto pRealSender = resolveSender();
-            auto pRealReceiver = resolveReceiver();
+            auto *pRealSender = resolveSender();
+            auto *pRealReceiver = resolveReceiver();
             if(pRealSender && pRealReceiver) {
                 activity->moveToThread(pRealSender->affinityThread());
                 if (pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
@@ -597,18 +597,18 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
 
         void removeConnectionReferences() {
-            auto pRealSender = resolveSender();
-            auto pRealReceiver = resolveReceiver();
+            auto *pRealSender = resolveSender();
+            auto *pRealReceiver = resolveReceiver();
             if(!pRealSender || !pRealReceiver) {
                 return;
             }
             m_removeConnectionReferenceImpl<TA_MetaObject, TA_MetaObject>(
-                pRealSender.get(), pRealReceiver.get(),
+                pRealSender, pRealReceiver,
                 std::forward<FuncMark>(m_senderFunc), std::forward<FuncMark>(m_receiverFunc));
         }
 
-        std::shared_ptr<TA_MetaObject> sender() const { return resolveSender(); }
-        std::shared_ptr<TA_MetaObject> receiver() const { return resolveReceiver(); }
+        TA_MetaObject *sender() const { return resolveSender(); }
+        TA_MetaObject *receiver() const { return resolveReceiver(); }
 
         using FuncMark = std::string_view;
 
@@ -616,8 +616,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         const FuncMark &slotMark() const { return m_receiverFunc; }
 
         bool isSync() const {
-            auto pRealSender = resolveSender();
-            auto pRealReceiver = resolveReceiver();
+            auto *pRealSender = resolveSender();
+            auto *pRealReceiver = resolveReceiver();
             if (!pRealSender || !pRealReceiver) return false;
 
             return pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
@@ -628,21 +628,19 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
 
       private:
         //Users need to ensure the validity of the returned pointer and check for nullptr before use.
-        std::shared_ptr<TA_MetaObject> resolveSender() const {
+        TA_MetaObject *resolveSender() const {
             bool isEmpty = !m_wpSender.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
                            !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpSender);
-            if (isEmpty)
-                return std::shared_ptr<TA_MetaObject>{(std::make_shared<TA_MetaObject>()), m_pSender};
-            return m_wpSender.lock();
+            if (isEmpty) return m_pSender;
+            return m_wpSender.lock().get();
         }
 
         //Users need to ensure the validity of the returned pointer and check for nullptr before use.
-        std::shared_ptr<TA_MetaObject> resolveReceiver() const {
+        TA_MetaObject *resolveReceiver() const {
             bool isEmpty = !m_wpReceiver.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
                            !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpReceiver);
-            if (isEmpty) 
-                return std::shared_ptr<TA_MetaObject>(std::make_shared<TA_MetaObject>(), m_pReceiver);
-            return m_wpReceiver.lock();
+            if (isEmpty) return m_pReceiver;
+            return m_wpReceiver.lock().get();
         }
 
       private:
@@ -710,7 +708,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
            Receiver pReceiver, TA_ConnectionObject::FuncMark &&slot) -> bool {
         auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signal);
         while (startSendIter != endSendIter) {
-            if (startSendIter->second->receiver().get() == pReceiver.get() &&
+            if (startSendIter->second->receiver() == pReceiver.get() &&
                 startSendIter->second->slotMark() == slot) {
                 return true;
             }
@@ -747,7 +745,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if (!pConnection) {
             return false;
         }
-        auto pSender = pConnection->sender();
+        Sender *pSender = pConnection->sender();
         if(pSender) {
             auto &&signalMark = pConnection->signalMark();
             auto &&slotMark = pConnection->slotMark();
@@ -775,7 +773,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             if (startSendIter == endSendIter)
                 return false;
             while (startSendIter != endSendIter) {
-                if (startSendIter->second->receiver().get() == pReceiver.get() &&
+                if (startSendIter->second->receiver() == pReceiver.get() &&
                     startSendIter->second->slotMark() == slot) {
                     pConnection = startSendIter->second;
                     pSender->m_outputConnections.erase(startSendIter);
@@ -834,7 +832,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         TA_ConnectionObject::FuncMark slotMark{typeid(Exp).name()};
         auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
         while (startSendIter != endSendIter) {
-            if (startSendIter->second->receiver().get() == pSender.get() && startSendIter->second->slotMark() == slotMark) {
+            if (startSendIter->second->receiver() == pSender.get() && startSendIter->second->slotMark() == slotMark) {
                 return {nullptr};
             }
             startSendIter++;
@@ -863,7 +861,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
                     Reflex::TA_TypeInfo<std::decay_t<RawSenderType>>::findName(std::forward<Signal>(signal))};
                 auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
                 while (startSendIter != endSendIter) {
-                    if (startSendIter->second->receiver().get() == pReceiver.get() &&
+                    if (startSendIter->second->receiver() == pReceiver.get() &&
                         startSendIter->second->slotMark() == slotMark) {
                         return false;
                     }
@@ -891,7 +889,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
                     Reflex::TA_TypeInfo<std::decay_t<RawSenderType>>::findName(std::forward<Signal>(signal))};
                 auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
                 while (startSendIter != endSendIter) {
-                    if (startSendIter->second->receiver().get() == pReceiver.get() &&
+                    if (startSendIter->second->receiver() == pReceiver.get() &&
                         startSendIter->second->slotMark() == slotMark) {
                         return nullptr;
                     }
@@ -949,7 +947,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             [](Sender *pSender, TA_ConnectionObject::FuncMark &&signal) -> void {
             auto rangeSender = pSender->m_outputConnections.equal_range(signal);
             for (auto iter = rangeSender.first; iter != rangeSender.second; ++iter) {
-                if (iter->second->sender().get() == pSender) {
+                if (iter->second->sender() == pSender) {
                     pSender->m_outputConnections.erase(iter);
                     break;
                 }
@@ -962,7 +960,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         auto receiverExp = [pReceiver, &slot]() -> void {
             auto rangeReceiver = pReceiver->m_inputConnections.equal_range(slot);
             for (auto iter = rangeReceiver.first; iter != rangeReceiver.second; ++iter) {
-                if (iter->second->receiver().get() == pReceiver) {
+                if (iter->second->receiver() == pReceiver) {
                     pReceiver->m_inputConnections.erase(iter);
                     break;
                 }

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -306,7 +306,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             return m_moveToThreadImpl(idx, m_affinityThreadIdx);
         }
         auto activity = TA_ActivityCreator::create(
-            std::forward<bool (*)(std::size_t, std::atomic_size_t &)>(m_moveToThreadImpl), idx, m_affinityThreadIdx);
+            std::forward<decltype(m_moveToThreadImpl)>(m_moveToThreadImpl), idx, m_affinityThreadIdx);
         activity->setStolenEnabled(false);
         AsyncTaskRes res = invokeActivity(activity, this);
         auto taskResult = res.get();

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -119,19 +119,19 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     }
 
     void pendingCountIncrement() {
-        m_pendingCounter.increment(); 
+        m_pendingCounter.increment();
     }
 
     void pendingCountDecrement() {
-        m_pendingCounter.decrement(); 
+        m_pendingCounter.decrement();
     }
 
     bool isIdle() const {
-        return m_pendingCounter.isIdle(); 
+        return m_pendingCounter.isIdle();
     }
 
     void resetPendingCount() {
-        m_pendingCounter.reset(); 
+        m_pendingCounter.reset();
     }
 
   protected:
@@ -147,7 +147,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             m_counter.fetch_sub(1, std::memory_order_acquire);
         }
         bool isIdle() const {
-            return m_counter.load(std::memory_order_acquire) == 0; 
+            return m_counter.load(std::memory_order_acquire) == 0;
         }
         auto operator ++ () -> PendingCounter & {
             increment();
@@ -164,7 +164,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     }
 
     std::shared_ptr<TA_MetaObject> sharedPtr() {
-        return this->shared_from_this(); 
+        return this->shared_from_this();
     }
 
     template <ActivityType Activity>
@@ -219,7 +219,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         pHost->pendingCountDecrement();
         co_return;
     }
-    
+
     inline static bool isOnCurrentThread(TA_MetaObject *pObject) {
         if (!pObject) {
             return false;
@@ -410,16 +410,25 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         if (!pSender) {
             return false;
         }
-        auto sharedSender = sharedRef(pSender);
         if(isOnCurrentThread(pSender)) {
-            m_emitSignalImpl<std::shared_ptr<Sender>, Signal, Args...>(sharedSender, std::forward<Signal>(signal), std::forward<Args>(args)...);
+            m_emitSignalImpl<Sender *, Signal, Args...>(pSender, std::forward<Signal>(signal), std::forward<Args>(args)...);
         } else {
-            using SharedExpType = decltype(m_emitSignalImpl<std::shared_ptr<Sender>, Signal, Args...>);
-            auto activity = TA_ActivityCreator::create(
-                std::forward<SharedExpType>(m_emitSignalImpl<std::shared_ptr<Sender>, Signal, Args...>),
-                std::move(sharedSender), std::forward<Signal>(signal), std::forward<Args>(args)...);
-            activity->setStolenEnabled(false);
-            invokeActivityNoAwait(activity, pSender);
+            if(!pSender->hasSharedRef()) {
+                using RawPtrExpType = decltype(m_emitSignalImpl<Sender *, Signal, Args...>);
+                auto activity = TA_ActivityCreator::create(
+                    std::forward<RawPtrExpType>(m_emitSignalImpl<Sender *, Signal, Args...>),
+                    pSender, std::forward<Signal>(signal), std::forward<Args>(args)...);
+                activity->setStolenEnabled(false);
+                invokeActivityNoAwait(activity, pSender);
+            } else {
+                auto sharedSender = sharedRef(pSender);
+                using SharedExpType = decltype(m_emitSignalImpl<std::shared_ptr<Sender>, Signal, Args...>);
+                auto activity = TA_ActivityCreator::create(
+                    std::forward<SharedExpType>(m_emitSignalImpl<std::shared_ptr<Sender>, Signal, Args...>),
+                    std::move(sharedSender), std::forward<Signal>(signal), std::forward<Args>(args)...);
+                activity->setStolenEnabled(false);
+                invokeActivityNoAwait(activity, pSender);
+            }
         }
         return true;
     }
@@ -621,7 +630,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     }
 
     void updateAffinityThread() {
-        m_affinityThreadIdx.store(TA_ThreadHolder::get().topPriorityThread(), std::memory_order_release); 
+        m_affinityThreadIdx.store(TA_ThreadHolder::get().topPriorityThread(), std::memory_order_release);
     }
 
   private:
@@ -648,7 +657,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         return false;
     };
 
-    template <SmartPtrType Sender, typename Signal, typename... Args>
+    template <PointerType Sender, typename Signal, typename... Args>
     inline static auto m_emitSignalImpl = [](Sender pSender, Signal signal, Args... args) -> void {
         if (!pSender) {
             return;
@@ -896,7 +905,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
     };
 };
 
-template <EnableConnectObjectType Sender, typename... Args> 
+template <EnableConnectObjectType Sender, typename... Args>
 class TA_SignalAwaitable : public std::enable_shared_from_this<TA_SignalAwaitable<Sender, Args...>> {
   public:
     TA_SignalAwaitable(Sender *pObject, void (std::decay_t<Sender>::*signal)(Args...))
@@ -906,7 +915,7 @@ class TA_SignalAwaitable : public std::enable_shared_from_this<TA_SignalAwaitabl
 
     constexpr bool await_ready() const noexcept { return false; }
 
-    template <typename PromiseType> 
+    template <typename PromiseType>
     constexpr void await_suspend(std::coroutine_handle<PromiseType> handle) noexcept {
         TA_MetaObject::registerConnection(
             m_pObject, std::move(m_signal),

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -220,7 +220,8 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         co_return;
     }
 
-    inline static bool isOnCurrentThread(TA_MetaObject *pObject) {
+    template <PointerType Ptr>
+    inline static bool isOnCurrentThread(Ptr pObject) {
         if (!pObject) {
             return false;
         }

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -568,7 +568,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
 
         std::shared_ptr<TA_ConnectionObject> getSharedPtr() { return this->shared_from_this(); }
-        std::weak_ptr<TA_ConnectionObject> getWeakPtr() { return this->weak_from_this(); };
+        std::weak_ptr<TA_ConnectionObject> getWeakPtr() { return this->weak_from_this(); }
 
         template <typename... Args> void setPara(Args &&...args) {
             using ArgsTypes = std::tuple<std::decay_t<Args>...>;

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -626,6 +626,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         bool isAutoDestroy() const { return m_autoDestroy; }
 
       private:
+        //Users need to ensure the validity of the returned pointer and check for nullptr before use.
         TA_MetaObject *resolveSender() const {
             bool isEmpty = !m_wpSender.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
                            !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpSender);
@@ -633,6 +634,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             return m_wpSender.lock().get();
         }
 
+        //Users need to ensure the validity of the returned pointer and check for nullptr before use.
         TA_MetaObject *resolveReceiver() const {
             bool isEmpty = !m_wpReceiver.owner_before(std::weak_ptr<TA_MetaObject>{}) && 
                            !std::weak_ptr<TA_MetaObject>{}.owner_before(m_wpReceiver);
@@ -653,10 +655,14 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
   private:
     void destroyConnections() {
         for (auto &&[signal, obj] : m_outputConnections) {
-            auto &&[start, end] = obj->receiver()->m_inputConnections.equal_range(obj->slotMark());
+            auto receiver = obj->receiver();
+            if(!receiver) {
+                continue;
+            }
+            auto &&[start, end] = receiver->m_inputConnections.equal_range(obj->slotMark());
             while (start != end) {
                 if (start->second == obj) {
-                    obj->receiver()->m_inputConnections.erase(start);
+                    receiver->m_inputConnections.erase(start);
                     break;
                 }
                 ++start;
@@ -665,10 +671,14 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         m_outputConnections.clear();
 
         for (auto &&[slot, obj] : m_inputConnections) {
-            auto &&[start, end] = obj->sender()->m_outputConnections.equal_range(obj->signalMark());
+            auto sender = obj->sender();
+            if(!sender) {
+                continue;
+            }
+            auto &&[start, end] = sender->m_outputConnections.equal_range(obj->signalMark());
             while (start != end) {
                 if (start->second == obj) {
-                    obj->sender()->m_outputConnections.erase(start);
+                    sender->m_outputConnections.erase(start);
                     break;
                 }
                 ++start;
@@ -735,17 +745,19 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             return false;
         }
         Sender *pSender = pConnection->sender();
-        auto &&signalMark = pConnection->signalMark();
-        auto &&slotMark = pConnection->slotMark();
-        auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
-        if (startSendIter == endSendIter)
-            return false;
-        while (startSendIter != endSendIter) {
-            if (startSendIter->second == pConnection) {
-                pSender->m_outputConnections.erase(startSendIter);
-                break;
+        if(pSender) {
+            auto &&signalMark = pConnection->signalMark();
+            auto &&slotMark = pConnection->slotMark();
+            auto &&[startSendIter, endSendIter] = pSender->m_outputConnections.equal_range(signalMark);
+            if (startSendIter == endSendIter)
+                return false;
+            while (startSendIter != endSendIter) {
+                if (startSendIter->second == pConnection) {
+                    pSender->m_outputConnections.erase(startSendIter);
+                    break;
+                }
+                startSendIter++;
             }
-            startSendIter++;
         }
         holder.reset();
         return true;

--- a/ActivityFramework/Src/Components/TA_MetaObject.h
+++ b/ActivityFramework/Src/Components/TA_MetaObject.h
@@ -530,16 +530,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         TA_ConnectionObject &operator=(const TA_ConnectionObject &object) = delete;
         TA_ConnectionObject &operator=(TA_ConnectionObject &&object) = delete;
 
-        ~TA_ConnectionObject() {
-            if (m_pSlotProxy) {
-                delete m_pSlotProxy;
-                m_pSlotProxy = nullptr;
-            }
-            if (m_pActivity) {
-                delete m_pActivity;
-                m_pActivity = nullptr;
-            }
-        }
+        ~TA_ConnectionObject() = default;
 
         template <EnableConnectObjectType Receiver, typename Slot>
         void initSlotObject(Receiver *pReceiver, Slot &&slot) {
@@ -552,7 +543,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             using Ret = typename MethodTypeInfo<Slot>::RetType;
             m_para = SlotParaTuple{};
             auto sharedRef = getSharedPtr();
-            SlotExpType slotExp = [sharedRef, slot]() -> void {
+            m_slotExp = [sharedRef, slot]() -> void {
                 auto *pRawReceiver = sharedRef->resolveReceiver();
                 if(!pRawReceiver) {
                     return;
@@ -562,12 +553,6 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
                     std::apply(slot, std::move(std::tuple_cat(std::make_tuple(rObj),
                                                               std::any_cast<SlotParaTuple>(sharedRef->m_para))));
             };
-            {
-                m_pActivity = TA_ActivityCreator::create(std::move(slotExp));
-                m_pActivity->moveToThread(pReceiver->affinityThread());
-                m_pActivity->setStolenEnabled(false);
-                m_pSlotProxy = new TA_ActivityProxy(m_pActivity, false);
-            }
         }
 
         template <LambdaExpType LambdaExp>
@@ -577,16 +562,9 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
             using Ret = typename LambdaExpTraits<std::decay_t<LambdaExp>>::RetType;
             m_para = SlotParaTuple{};
             auto sharedRef = getSharedPtr();
-            SlotExpType slotExp = [sharedRef, exp]() -> void {
+            m_slotExp = [sharedRef, exp]() -> void {
                 std::apply(exp, std::any_cast<SlotParaTuple>(sharedRef->m_para));
             };
-            {
-                m_pActivity = TA_ActivityCreator::create(std::move(slotExp));
-                // Don't need to ensure the activity is moved to the sender's affinity thread
-                // m_pActivity->moveToThread(m_pSender->affinityThread());
-                m_pActivity->setStolenEnabled(false);
-                m_pSlotProxy = new TA_ActivityProxy(m_pActivity, false);
-            }
         }
 
         std::shared_ptr<TA_ConnectionObject> getSharedPtr() { return this->shared_from_this(); }
@@ -599,17 +577,17 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         }
 
         void callSlot() {
-            if (m_pActivity) {
-                auto *pRealSender = resolveSender();
-                auto *pRealReceiver = resolveReceiver();
-                if(pRealSender && pRealReceiver) {
-                    if (pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
-                        (m_type == TA_ConnectionType::Direct || m_type == TA_ConnectionType::Auto)) {
-                        m_pActivity->operator()();
-                    } else {
-                        auto fetcher = TA_ThreadHolder::get().postActivity(m_pSlotProxy);
-                        m_pSlotProxy = new TA_ActivityProxy(m_pActivity, false);
-                    }
+            auto activity = TA_ActivityCreator::create(std::forward<SlotExpType>(m_slotExp));
+            activity->setStolenEnabled(false);
+            auto *pRealSender = resolveSender();
+            auto *pRealReceiver = resolveReceiver();
+            if(pRealSender && pRealReceiver) {
+                activity->moveToThread(pRealSender->affinityThread());
+                if (pRealSender->affinityThread() == pRealReceiver->affinityThread() &&
+                    (m_type == TA_ConnectionType::Direct || m_type == TA_ConnectionType::Auto)) {
+                    activity->operator()();
+                } else {
+                    auto fetcher = TA_ThreadHolder::get().postActivity(activity, true);
                 }
             }
             if (m_autoDestroy) {
@@ -668,8 +646,7 @@ class TA_MetaObject : public std::enable_shared_from_this<TA_MetaObject> {
         FuncMark m_senderFunc{}, m_receiverFunc{};
         TA_ConnectionType m_type;
         std::any m_para;
-        TA_MethodActivity<SlotExpType> *m_pActivity{nullptr};
-        TA_ActivityProxy *m_pSlotProxy{nullptr};
+        SlotExpType m_slotExp {};
         const bool m_autoDestroy{false};
     };
 

--- a/ActivityFramework/Src/Components/TA_ThreadPool.h
+++ b/ActivityFramework/Src/Components/TA_ThreadPool.h
@@ -175,7 +175,9 @@ class ACTIVITY_FRAMEWORK_EXPORT TA_ThreadPool {
     [[nodiscard]] auto postActivity(TA_ActivityProxy *&pActivity) -> TA_ActivityResultFetcher {
         if (!pActivity)
             throw std::invalid_argument("Activity proxy is null");
-        std::shared_ptr<TA_ActivityProxy> pProxy{pActivity};
+        auto weakRef = pActivity->weakRef();
+        std::shared_ptr<TA_ActivityProxy> pProxy =
+            weakRef.expired() ? std::shared_ptr<TA_ActivityProxy>(pActivity) : weakRef.lock();
         auto affinityId{pActivity->affinityThread()};
         auto dependencyThreadId{pActivity->dependencyThreadId()};
         pActivity = nullptr;
@@ -192,6 +194,26 @@ class ACTIVITY_FRAMEWORK_EXPORT TA_ThreadPool {
 #endif
         m_states[idx].resource.release();
         return {pProxy};
+    }
+
+    [[nodiscard]] auto postActivity(const std::shared_ptr<TA_ActivityProxy> &pActivity) -> TA_ActivityResultFetcher {
+        if (!pActivity)
+            throw std::invalid_argument("Activity proxy is null");
+        auto affinityId{pActivity->affinityThread()};
+        auto dependencyThreadId{pActivity->dependencyThreadId()};
+        std::size_t idx = affinityId < m_threads.size() ? affinityId : topPriorityThread(dependencyThreadId);
+        //std::cout << "Post activity to thread: " << idx << "\n";
+#if defined(__ANDROID__)
+            auto handle = std::unique_ptr<HandleType>(new HandleType{pActivity});
+            if (!m_activityQueues[idx].push(handle.get()))
+                throw std::runtime_error("Failed to push activity to queue");
+            handle.release();
+#else
+            if (!m_activityQueues[idx].push(pActivity))
+                throw std::runtime_error("Failed to push activity to queue");
+#endif
+        m_states[idx].resource.release();
+        return {pActivity};
     }
 
     std::size_t size() const { return m_threads.size(); }

--- a/ActivityFramework/Src/Components/TA_TypeFilter.h
+++ b/ActivityFramework/Src/Components/TA_TypeFilter.h
@@ -34,6 +34,21 @@ struct IsSmartPtr<T, std::void_t<decltype(*std::declval<T &>()), decltype(std::d
 
 template <typename T> constexpr bool IsSmartPtr_v = IsSmartPtr<T>::value;
 
+template <typename T>
+concept SmartPtrType = IsSmartPtr_v<T>;
+
+template <typename T>
+struct ExtractRawType {
+    using type = std::conditional_t<
+        std::is_pointer_v<T>,
+        std::decay_t<std::remove_pointer_t<T>>,
+        std::decay_t<T>>;
+};
+
+template <typename T> requires IsSmartPtr_v<T>
+struct ExtractRawType<T> {
+    using type = std::decay_t<typename T::element_type>;
+};
 
 template <typename T> struct IsStdFunction : std::false_type {};
 

--- a/ActivityFramework/Src/Components/TA_TypeFilter.h
+++ b/ActivityFramework/Src/Components/TA_TypeFilter.h
@@ -249,6 +249,9 @@ concept RawPtr = requires(T t) {
 };
 
 template <typename T>
+concept PointerType = IsRawPtr<T> || SmartPtrType<T>;
+
+template <typename T>
 concept IsEnumType = std::is_enum_v<std::decay_t<T>>;
 
 template <typename T>

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -44,11 +44,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
             m_isSmallObject = true;
         } else {
             m_storage.m_ptr = std::make_shared<RawType>(std::forward<RawType>(value), std::forward<Args>(args)...);
-            m_destroySSOExp = [](void *ptr) {
-                if (ptr)
-                    std::destroy_at(reinterpret_cast<RawType *>(ptr)); 
-                ptr = nullptr;
-            };
+            m_destroySSOExp = nullptr;
             m_isSmallObject = false;
         }
     }
@@ -170,8 +166,10 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         if (m_typeId != 0 && m_destroySSOExp) {
             if (m_isSmallObject)
                 m_destroySSOExp(m_storage.m_data);
-            else
+            else {
                 m_storage.m_ptr.reset();
+                std::destroy_at(&m_storage.m_ptr);
+            }
         }
         m_destroySSOExp = nullptr;
     }

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -33,6 +33,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         using RawType = std::remove_cvref_t<T>;
         m_typeId = typeid(RawType).hash_code();
         if constexpr (sizeof(RawType) <= ms_smallObjSize && std::alignment_of_v<RawType> <= ms_alignment) {
+            std::destroy_at(&m_storage.m_ptr);
             new (m_storage.m_data) RawType(std::forward<RawType>(value), std::forward<Args>(args)...);
             m_destroySSOExp = [](void *data) { std::destroy_at(reinterpret_cast<RawType *>(data)); };
             m_copySSOExp = [](const void *src, void *dst) {
@@ -86,7 +87,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
                     var.m_copySSOExp(var.m_storage.m_data, m_storage.m_data);
                 }
             } else {
-                m_storage.m_ptr = var.m_storage.m_ptr;
+                new (&m_storage.m_ptr) std::shared_ptr<void>(var.m_storage.m_ptr);
             }
             m_destroySSOExp = var.m_destroySSOExp;
             m_copySSOExp = var.m_copySSOExp;
@@ -98,14 +99,14 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
     TA_Variant &operator=(TA_Variant &&var) noexcept {
         if (this != &var) {
             destroy();
-            m_typeId = std::exchange(var.m_typeId, 0);
+            m_typeId = std::exchange(var.m_typeId, typeid(std::nullptr_t).hash_code());
             m_isSmallObject = std::exchange(var.m_isSmallObject, false);
             if (m_isSmallObject) {
                 if (var.m_moveSSOExp) {
                     var.m_moveSSOExp(var.m_storage.m_data, m_storage.m_data);
                 }
             } else {
-                m_storage.m_ptr = std::exchange(var.m_storage.m_ptr, nullptr);
+                new (&m_storage.m_ptr) std::shared_ptr<void>(std::exchange(var.m_storage.m_ptr, nullptr));
             }
             m_destroySSOExp = std::exchange(var.m_destroySSOExp, nullptr);
             m_copySSOExp = std::exchange(var.m_copySSOExp, nullptr);
@@ -132,7 +133,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
                 };
                 m_isSmallObject = true;
             } else {
-                m_storage.m_ptr = std::make_shared<RawType>(std::forward<RawType>(obj));
+                new (&m_storage.m_ptr) std::shared_ptr<void>(std::make_shared<RawType>(std::forward<RawType>(obj)));
                 m_destroySSOExp = nullptr;
                 m_copySSOExp = nullptr;
                 m_moveSSOExp = nullptr;
@@ -163,13 +164,11 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
 
   private:
     void destroy() {
-        if (m_typeId != 0 && m_destroySSOExp) {
-            if (m_isSmallObject)
+        if (m_isSmallObject) {
+            if (m_destroySSOExp)
                 m_destroySSOExp(m_storage.m_data);
-            else {
-                m_storage.m_ptr.reset();
-                std::destroy_at(&m_storage.m_ptr);
-            }
+        } else {
+            std::destroy_at(&m_storage.m_ptr);
         }
         m_destroySSOExp = nullptr;
     }

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -26,6 +26,11 @@
 
 namespace CoreAsync {
 template <std::size_t SSO_SIZE = 64> class TA_Variant {
+    enum class StorageKind {
+        Empty,
+        SmallObject,
+        HeapObject
+    };
   public:
     TA_Variant() {}
 
@@ -45,36 +50,36 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
             m_moveSSOExp = [](void *src, void *dst) {
                 new (dst) RawType(std::move(*reinterpret_cast<RawType *>(src)));
             };
-            m_isSmallObject = true;
+            m_storageKind = StorageKind::SmallObject;
         } else {
             m_storage.m_ptr = std::make_shared<RawType>(std::forward<T>(value), std::forward<Args>(args)...);
             m_destroySSOExp = nullptr;
-            m_isSmallObject = false;
+            m_storageKind = StorageKind::HeapObject;
         }
     }
 
     ~TA_Variant() { destroy(); }
 
     TA_Variant(const TA_Variant &var) noexcept
-        : m_typeId(var.m_typeId), m_isSmallObject(var.m_isSmallObject), m_destroySSOExp(var.m_destroySSOExp),
+        : m_typeId(var.m_typeId), m_storageKind(var.m_storageKind), m_destroySSOExp(var.m_destroySSOExp),
           m_copySSOExp(var.m_copySSOExp), m_moveSSOExp(var.m_moveSSOExp) {
-        if (m_isSmallObject) {
+        if (m_storageKind == StorageKind::SmallObject) {
              std::destroy_at(&m_storage.m_ptr);
             if (var.m_copySSOExp) {
                 var.m_copySSOExp(var.m_storage.m_data, m_storage.m_data);
             }
-        } else {
+        } else if (m_storageKind == StorageKind::HeapObject) {
             m_storage.m_ptr = var.m_storage.m_ptr;
         }
     }
 
-    TA_Variant(TA_Variant &&var) noexcept : m_typeId(std::move(var.m_typeId)), m_isSmallObject(std::move(var.m_isSmallObject)) {
-        if (m_isSmallObject) {
+    TA_Variant(TA_Variant &&var) noexcept : m_typeId(std::move(var.m_typeId)), m_storageKind(std::move(var.m_storageKind)) {
+        if (m_storageKind == StorageKind::SmallObject) {
             std::destroy_at(&m_storage.m_ptr);
             if (var.m_moveSSOExp) {
                 var.m_moveSSOExp(var.m_storage.m_data, m_storage.m_data);
             }
-        } else {
+        } else if (m_storageKind == StorageKind::HeapObject) {
             m_storage.m_ptr = std::exchange(var.m_storage.m_ptr, nullptr);
         }
         m_destroySSOExp = std::move(var.m_destroySSOExp);
@@ -86,12 +91,12 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         if (this != &var) {
             destroy();
             m_typeId = var.m_typeId;
-            m_isSmallObject = var.m_isSmallObject;
-            if (m_isSmallObject) {
+            m_storageKind = var.m_storageKind;
+            if (m_storageKind == StorageKind::SmallObject) {
                 if (var.m_copySSOExp) {
                     var.m_copySSOExp(var.m_storage.m_data, m_storage.m_data);
                 }
-            } else {
+            } else if (m_storageKind == StorageKind::HeapObject) {
                 new (&m_storage.m_ptr) std::shared_ptr<void>(var.m_storage.m_ptr);
             }
             m_destroySSOExp = var.m_destroySSOExp;
@@ -105,12 +110,12 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         if (this != &var) {
             destroy();
             m_typeId = std::move(var.m_typeId);
-            m_isSmallObject = std::move(var.m_isSmallObject);
-            if (m_isSmallObject) {
+             m_storageKind = std::move(var.m_storageKind);
+            if (m_storageKind == StorageKind::SmallObject) {
                 if (var.m_moveSSOExp) {
                     var.m_moveSSOExp(var.m_storage.m_data, m_storage.m_data);
                 }
-            } else {
+            } else if (m_storageKind == StorageKind::HeapObject) {
                 new (&m_storage.m_ptr) std::shared_ptr<void>(std::exchange(var.m_storage.m_ptr, nullptr));
             }
             m_destroySSOExp = std::move(var.m_destroySSOExp);
@@ -136,13 +141,13 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
                 m_moveSSOExp = [](void *src, void *dst) {
                     new (dst) RawType(std::move(*reinterpret_cast<RawType *>(src)));
                 };
-                m_isSmallObject = true;
+                m_storageKind = StorageKind::SmallObject;
             } else {
                 new (&m_storage.m_ptr) std::shared_ptr<void>(std::make_shared<T>(std::forward<RawType>(obj)));
                 m_destroySSOExp = nullptr;
                 m_copySSOExp = nullptr;
                 m_moveSSOExp = nullptr;
-                m_isSmallObject = false;
+                m_storageKind = StorageKind::HeapObject;
             }
         }
     }
@@ -151,9 +156,9 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
     VAR get() const /* requires (!std::is_pointer<VAR>::value)*/
     {
         if (m_typeId == typeid(VAR).hash_code()) {
-            if (m_isSmallObject) {
+            if (m_storageKind == StorageKind::SmallObject) {
                 return *reinterpret_cast<const VAR *>(m_storage.m_data);
-            } else {
+            } else if (m_storageKind == StorageKind::HeapObject) {
                 return *reinterpret_cast<VAR *>(m_storage.m_ptr.get());
             }
         }
@@ -169,13 +174,15 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
 
   private:
     void destroy() {
-        if (m_isSmallObject) {
+        if(m_storageKind == StorageKind::Empty) return;
+        if (m_storageKind == StorageKind::SmallObject) {
             if (m_destroySSOExp)
                 m_destroySSOExp(m_storage.m_data);
-        } else {
+        } else if (m_storageKind == StorageKind::HeapObject) {
             std::destroy_at(&m_storage.m_ptr);
         }
         m_destroySSOExp = nullptr;
+        m_storageKind = StorageKind::Empty;
     }
 
   private:
@@ -191,7 +198,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         ~Storage() {}
     } m_storage;
 
-    bool m_isSmallObject{false};
+    StorageKind m_storageKind{StorageKind::Empty};
     void (*m_destroySSOExp)(void *){nullptr};
     void (*m_copySSOExp)(const void *, void *){nullptr};
     void (*m_moveSSOExp)(void *, void *){nullptr};

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -198,7 +198,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         ~Storage() {}
     } m_storage;
 
-    StorageKind m_storageKind{StorageKind::Empty};
+    StorageKind m_storageKind{StorageKind::HeapObject};
     void (*m_destroySSOExp)(void *){nullptr};
     void (*m_copySSOExp)(const void *, void *){nullptr};
     void (*m_moveSSOExp)(void *, void *){nullptr};

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -143,7 +143,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
                 };
                 m_storageKind = StorageKind::SmallObject;
             } else {
-                new (&m_storage.m_ptr) std::shared_ptr<void>(std::make_shared<T>(std::forward<RawType>(obj)));
+                new (&m_storage.m_ptr) std::shared_ptr<void>(std::make_shared<RawType>(std::forward<T>(obj)));
                 m_destroySSOExp = nullptr;
                 m_copySSOExp = nullptr;
                 m_moveSSOExp = nullptr;

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -56,6 +56,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         : m_typeId(var.m_typeId), m_isSmallObject(var.m_isSmallObject), m_destroySSOExp(var.m_destroySSOExp),
           m_copySSOExp(var.m_copySSOExp), m_moveSSOExp(var.m_moveSSOExp) {
         if (m_isSmallObject) {
+             std::destroy_at(&m_storage.m_ptr);
             if (var.m_copySSOExp) {
                 var.m_copySSOExp(var.m_storage.m_data, m_storage.m_data);
             }
@@ -66,6 +67,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
 
     TA_Variant(TA_Variant &&var) noexcept : m_typeId(std::move(var.m_typeId)), m_isSmallObject(std::move(var.m_isSmallObject)) {
         if (m_isSmallObject) {
+            std::destroy_at(&m_storage.m_ptr);
             if (var.m_moveSSOExp) {
                 var.m_moveSSOExp(var.m_storage.m_data, m_storage.m_data);
             }

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -77,9 +77,9 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         } else {
             m_storage.m_ptr = std::exchange(var.m_storage.m_ptr, nullptr);
         }
-        m_destroySSOExp = std::exchange(var.m_destroySSOExp, nullptr);
-        m_copySSOExp = std::exchange(var.m_copySSOExp, nullptr);
-        m_moveSSOExp = std::exchange(var.m_moveSSOExp, nullptr);
+        m_destroySSOExp = std::move(var.m_destroySSOExp);
+        m_copySSOExp = std::move(var.m_copySSOExp);
+        m_moveSSOExp = std::move(var.m_moveSSOExp);
     }
 
     TA_Variant &operator=(const TA_Variant &var) {
@@ -104,8 +104,8 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
     TA_Variant &operator=(TA_Variant &&var) noexcept {
         if (this != &var) {
             destroy();
-            m_typeId = std::exchange(var.m_typeId, typeid(std::nullptr_t).hash_code());
-            m_isSmallObject = std::exchange(var.m_isSmallObject, false);
+            m_typeId = std::move(var.m_typeId);
+            m_isSmallObject = std::move(var.m_isSmallObject);
             if (m_isSmallObject) {
                 if (var.m_moveSSOExp) {
                     var.m_moveSSOExp(var.m_storage.m_data, m_storage.m_data);
@@ -113,9 +113,9 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
             } else {
                 new (&m_storage.m_ptr) std::shared_ptr<void>(std::exchange(var.m_storage.m_ptr, nullptr));
             }
-            m_destroySSOExp = std::exchange(var.m_destroySSOExp, nullptr);
-            m_copySSOExp = std::exchange(var.m_copySSOExp, nullptr);
-            m_moveSSOExp = std::exchange(var.m_moveSSOExp, nullptr);
+            m_destroySSOExp = std::move(var.m_destroySSOExp);
+            m_copySSOExp = std::move(var.m_copySSOExp);
+            m_moveSSOExp = std::move(var.m_moveSSOExp);
         }
         return *this;
     }

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -42,7 +42,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         m_typeId = typeid(RawType).hash_code();
         if constexpr (sizeof(RawType) <= ms_smallObjSize && std::alignment_of_v<RawType> <= ms_alignment) {
             std::destroy_at(&m_storage.m_ptr);
-            new (m_storage.m_data) RawType(std::forward<RawType>(value), std::forward<Args>(args)...);
+            new (m_storage.m_data) RawType(std::forward<T>(value), std::forward<Args>(args)...);
             m_destroySSOExp = [](void *data) { std::destroy_at(reinterpret_cast<RawType *>(data)); };
             m_copySSOExp = [](const void *src, void *dst) {
                 new (dst) RawType(*reinterpret_cast<const RawType *>(src));
@@ -133,7 +133,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
         } else {
             m_typeId = typeid(RawType).hash_code();
             if constexpr (sizeof(RawType) <= ms_smallObjSize && std::alignment_of_v<RawType> <= ms_alignment) {
-                new (m_storage.m_data) RawType(std::forward<RawType>(obj));
+                new (m_storage.m_data) RawType(std::forward<T>(obj));
                 m_destroySSOExp = [](void *data) { std::destroy_at(reinterpret_cast<RawType *>(data)); };
                 m_copySSOExp = [](const void *src, void *dst) {
                     new (dst) RawType(*reinterpret_cast<const RawType *>(src));

--- a/ActivityFramework/Src/Components/TA_Variant.h
+++ b/ActivityFramework/Src/Components/TA_Variant.h
@@ -29,7 +29,10 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
   public:
     TA_Variant() {}
 
-    template <typename T, typename... Args> TA_Variant(T &&value, Args &&...args) noexcept {
+    template <typename T, typename... Args>
+        requires(!std::is_same_v<std::remove_cvref_t<T>, TA_Variant> &&
+            !std::is_same_v<std::remove_cvref_t<T>, std::in_place_t>)
+    TA_Variant(T &&value, Args &&...args) noexcept {
         using RawType = std::remove_cvref_t<T>;
         m_typeId = typeid(RawType).hash_code();
         if constexpr (sizeof(RawType) <= ms_smallObjSize && std::alignment_of_v<RawType> <= ms_alignment) {
@@ -44,7 +47,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
             };
             m_isSmallObject = true;
         } else {
-            m_storage.m_ptr = std::make_shared<RawType>(std::forward<RawType>(value), std::forward<Args>(args)...);
+            m_storage.m_ptr = std::make_shared<RawType>(std::forward<T>(value), std::forward<Args>(args)...);
             m_destroySSOExp = nullptr;
             m_isSmallObject = false;
         }
@@ -135,7 +138,7 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
                 };
                 m_isSmallObject = true;
             } else {
-                new (&m_storage.m_ptr) std::shared_ptr<void>(std::make_shared<RawType>(std::forward<RawType>(obj)));
+                new (&m_storage.m_ptr) std::shared_ptr<void>(std::make_shared<T>(std::forward<RawType>(obj)));
                 m_destroySSOExp = nullptr;
                 m_copySSOExp = nullptr;
                 m_moveSSOExp = nullptr;
@@ -195,6 +198,10 @@ template <std::size_t SSO_SIZE = 64> class TA_Variant {
 };
 
 using TA_DefaultVariant = TA_Variant<>;
+
+template <typename T>
+TA_Variant(T&&) -> TA_Variant<64>;
+
 } // namespace CoreAsync
 
 #endif // TA_VARIANT_H

--- a/Test/ActivityFrameworkTest/TA_ConnectionTest.cpp
+++ b/Test/ActivityFrameworkTest/TA_ConnectionTest.cpp
@@ -18,6 +18,8 @@
 #include "ITA_Connection.h"
 #include "MetaTest.h"
 
+ConnectionHolder conn {};
+
 TA_ConnectionTest::TA_ConnectionTest() {}
 
 TA_ConnectionTest::~TA_ConnectionTest() {}
@@ -63,7 +65,7 @@ TEST_F(TA_ConnectionTest, asyncActiveTest) {
 
 TEST_F(TA_ConnectionTest, lambdaExpTest) {
     int c = 9;
-    auto conn = CoreAsync::ITA_Connection::connect(
+    conn = CoreAsync::ITA_Connection::connect(
         m_pTest.get(), &MetaTest::startTest, [c](int a, int b) { std::printf("The numbers are: %d, %d, %d\n.", a, b, c); });
     EXPECT_TRUE(conn.valid());
     EXPECT_TRUE(CoreAsync::ITA_Connection::active(m_pTest.get(), &MetaTest::startTest, 8, 8));

--- a/Test/ActivityFrameworkTest/TA_ConnectionTest.cpp
+++ b/Test/ActivityFrameworkTest/TA_ConnectionTest.cpp
@@ -18,8 +18,6 @@
 #include "ITA_Connection.h"
 #include "MetaTest.h"
 
-ConnectionHolder conn {};
-
 TA_ConnectionTest::TA_ConnectionTest() {}
 
 TA_ConnectionTest::~TA_ConnectionTest() {}
@@ -65,7 +63,7 @@ TEST_F(TA_ConnectionTest, asyncActiveTest) {
 
 TEST_F(TA_ConnectionTest, lambdaExpTest) {
     int c = 9;
-    conn = CoreAsync::ITA_Connection::connect(
+    ConnectionHolder conn = CoreAsync::ITA_Connection::connect(
         m_pTest.get(), &MetaTest::startTest, [c](int a, int b) { std::printf("The numbers are: %d, %d, %d\n.", a, b, c); });
     EXPECT_TRUE(conn.valid());
     EXPECT_TRUE(CoreAsync::ITA_Connection::active(m_pTest.get(), &MetaTest::startTest, 8, 8));

--- a/Test/ActivityFrameworkTest/TA_ThreadPoolTest.cpp
+++ b/Test/ActivityFrameworkTest/TA_ThreadPoolTest.cpp
@@ -17,7 +17,10 @@
 #include "TA_ThreadPoolTest.h"
 #include "Components/TA_Activity.h"
 
-TA_ThreadPoolTest::TA_ThreadPoolTest() {}
+TA_ThreadPoolTest::TA_ThreadPoolTest() {
+    activities.fill(nullptr);
+}
+
 
 TA_ThreadPoolTest::~TA_ThreadPoolTest() {}
 


### PR DESCRIPTION
This pull request refactors the activity pipeline framework to use smart pointers (`std::shared_ptr`) for managing `TA_ActivityProxy` objects throughout the codebase, replacing raw pointer usage. This change improves memory safety and simplifies resource management by leveraging automatic reference counting, eliminating the need for manual deletion. Additionally, the coroutines infrastructure is improved for correctness and clarity, and minor API improvements are made.

Key changes include:

### Smart Pointer Refactoring and Memory Management

* Replaced all usages of raw pointers (`TA_ActivityProxy*`) in activity pipelines, activity lists, and related APIs with `std::shared_ptr<TA_ActivityProxy>`, updating method signatures, member variables, and utility function calls accordingly. This eliminates manual `delete` calls and reduces the risk of memory leaks or dangling pointers. [[1]](diffhunk://#diff-f08d9e2a686105860fe4f8e00a81fc2f45fd10a0bdbfdd2a192a7a338da8ba0aR291-R304) [[2]](diffhunk://#diff-f08d9e2a686105860fe4f8e00a81fc2f45fd10a0bdbfdd2a192a7a338da8ba0aL344-R383) [[3]](diffhunk://#diff-7985f2060c44e76537401d576b306b46f8e331eeb7cd7e4f02b22d419df0c4fcL24-R24) [[4]](diffhunk://#diff-2a2da43ea9b38eb2db7fb71449eec4cf13976480b13a8f7453de2cf232f1b68aL31-R31) [[5]](diffhunk://#diff-2a2da43ea9b38eb2db7fb71449eec4cf13976480b13a8f7453de2cf232f1b68aL44-L49) [[6]](diffhunk://#diff-2a2da43ea9b38eb2db7fb71449eec4cf13976480b13a8f7453de2cf232f1b68aL59-L64) [[7]](diffhunk://#diff-edf25b18bd260a84bff86f91107c99719c638ba7e61acd5757afd06ae94551e8L149-R150) [[8]](diffhunk://#diff-edf25b18bd260a84bff86f91107c99719c638ba7e61acd5757afd06ae94551e8L171-R171) [[9]](diffhunk://#diff-d184159586d3ec74ffc95e7e200e5391eaf0e3c1da61a73f13df255777e44b37L24-R24) [[10]](diffhunk://#diff-d184159586d3ec74ffc95e7e200e5391eaf0e3c1da61a73f13df255777e44b37L52-L57) [[11]](diffhunk://#diff-5e01ab9a7855411690e1c4da1eb281d99f7943e43d4010fdcc3cb5246633276aL23-R23) [[12]](diffhunk://#diff-5e01ab9a7855411690e1c4da1eb281d99f7943e43d4010fdcc3cb5246633276aL72-L77) [[13]](diffhunk://#diff-9a20ddac0464555730cce8aba48b480306692fd7e8934b0945890de5627917d2L25-R25) [[14]](diffhunk://#diff-9a20ddac0464555730cce8aba48b480306692fd7e8934b0945890de5627917d2L96-L101) [[15]](diffhunk://#diff-9d2e43a07e2bb14000db780eaacd77f61ba596f98a904444b8e1ca87215a7243L25-R25) [[16]](diffhunk://#diff-9d2e43a07e2bb14000db780eaacd77f61ba596f98a904444b8e1ca87215a7243L77-L82)

* Updated `TA_ActivityProxy` to inherit from `std::enable_shared_from_this`, allowing creation of `shared_ptr` and `weak_ptr` references from within the object, and provided `sharedRef()` and `weakRef()` helper methods. [[1]](diffhunk://#diff-696d601e88052ba34fcf94bc240b9b1aa9c36d4e2fd7b4627c9831f34e3cd61bL36-R36) [[2]](diffhunk://#diff-696d601e88052ba34fcf94bc240b9b1aa9c36d4e2fd7b4627c9831f34e3cd61bR104-R120)

### Coroutine and Awaitable Improvements

* Modified coroutine promise types to use a custom `FinalAwaiter` for proper notification and completion signaling, and ensured coroutine handles are safely destroyed and nulled out after use. [[1]](diffhunk://#diff-84fd94133bc653e7459f7344542d9291fdecd2565f31d79d5f62e6a0b7cc8e8eR35-L55) [[2]](diffhunk://#diff-84fd94133bc653e7459f7344542d9291fdecd2565f31d79d5f62e6a0b7cc8e8eR120-L136) [[3]](diffhunk://#diff-84fd94133bc653e7459f7344542d9291fdecd2565f31d79d5f62e6a0b7cc8e8eR174)

* Updated `TA_ActivityFetcherAwaitable` and `TA_ActivityExecutingAwaitable` to use `std::shared_ptr<TA_ActivityProxy>`, deleted copy/move operations, and implemented the `operator co_await` for better coroutine integration. [[1]](diffhunk://#diff-f08d9e2a686105860fe4f8e00a81fc2f45fd10a0bdbfdd2a192a7a338da8ba0aR291-R304) [[2]](diffhunk://#diff-f08d9e2a686105860fe4f8e00a81fc2f45fd10a0bdbfdd2a192a7a338da8ba0aL344-R383)

### Miscellaneous Improvements

* Improved move constructor and assignment operator for `TA_ActivityProxy` to handle new member variables and atomic state. [[1]](diffhunk://#diff-696d601e88052ba34fcf94bc240b9b1aa9c36d4e2fd7b4627c9831f34e3cd61bL90-R92) [[2]](diffhunk://#diff-696d601e88052ba34fcf94bc240b9b1aa9c36d4e2fd7b4627c9831f34e3cd61bR104-R120)

* Minor API change: the `disconnect` method in `TA_Connection` now takes a non-const reference to allow proper connection management.

* Removed the now-unused header file `TA_ReceiverObject.h` from the build configuration.