### PR TITLE
Use awaiter for yield_value to notify completion

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Test (ctest)
       working-directory: ${{github.workspace}}/build-windows
-      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
+      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure --verbose
 
   Android_x86_64:
     runs-on: ubuntu-24.04

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    "configurations": [
+        {
+            "name": "Debug ActivityFrameworkTest (MSVC)",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/windows-msvc/debug/Test/ActivityFrameworkTest.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/windows-msvc/debug/Test",
+            "environment": [],
+            "console": "integratedTerminal",
+            "preLaunchTask": "CMake Build: Windows MSVC Debug"
+        },
+        {
+            "name": "Launch ActivityFrameworkTest Release (MSVC)",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/windows-msvc/release/Test/ActivityFrameworkTest.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/windows-msvc/release/Test",
+            "environment": [],
+            "console": "integratedTerminal",
+            "preLaunchTask": "CMake Build: Windows MSVC Release"
+        }
+    ],
+    "version": "2.0.0"
+}

--- a/.vscode/scripts/cmake-msvc.ps1
+++ b/.vscode/scripts/cmake-msvc.ps1
@@ -1,0 +1,90 @@
+param(
+    [ValidateSet("configure", "build", "test")]
+    [string]$Action = "build",
+
+    [ValidateSet("Debug", "Release")]
+    [string]$Config = "Debug"
+)
+
+$ErrorActionPreference = "Stop"
+
+$workspace = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$buildDir = Join-Path $workspace "build\windows-msvc\$($Config.ToLowerInvariant())"
+$testExe = Join-Path $buildDir "Test\ActivityFrameworkTest.exe"
+
+$vswhere = Get-Command "vswhere.exe" -ErrorAction SilentlyContinue
+if (-not $vswhere) {
+    $candidate = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $candidate) {
+        $vswherePath = $candidate
+    }
+} else {
+    $vswherePath = $vswhere.Source
+}
+
+if (-not $vswherePath) {
+    throw "Could not find vswhere.exe. Install Visual Studio Build Tools or add vswhere.exe to PATH."
+}
+
+$vsInstall = & $vswherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+if (-not $vsInstall) {
+    throw "Could not find a Visual Studio installation with the MSVC x64 tools."
+}
+
+$devCmd = Join-Path $vsInstall "Common7\Tools\VsDevCmd.bat"
+if (-not (Test-Path $devCmd)) {
+    throw "Could not find VsDevCmd.bat under '$vsInstall'."
+}
+
+$cmake = Get-Command "cmake.exe" -ErrorAction SilentlyContinue
+if ($cmake) {
+    $cmakePath = $cmake.Source
+} else {
+    $candidate = Join-Path $vsInstall "Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe"
+    if (Test-Path $candidate) {
+        $cmakePath = $candidate
+    }
+}
+
+if (-not $cmakePath) {
+    throw "Could not find cmake.exe on PATH or under the Visual Studio installation."
+}
+
+$ninja = Get-Command "ninja.exe" -ErrorAction SilentlyContinue
+if ($ninja) {
+    $ninjaPath = $ninja.Source
+} else {
+    $candidate = Join-Path $vsInstall "Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.exe"
+    if (Test-Path $candidate) {
+        $ninjaPath = $candidate
+    }
+}
+
+if (-not $ninjaPath) {
+    throw "Could not find ninja.exe on PATH or under the Visual Studio installation."
+}
+
+function Invoke-InVsDevCmd {
+    param([string]$CommandLine)
+
+    $cmd = "call `"$devCmd`" -arch=x64 -host_arch=x64 >nul && $CommandLine"
+    & cmd.exe /d /s /c "`"$cmd`""
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+switch ($Action) {
+    "configure" {
+        Invoke-InVsDevCmd "`"$cmakePath`" -S `"$workspace`" -B `"$buildDir`" -G Ninja -D CMAKE_MAKE_PROGRAM=`"$ninjaPath`" -D CMAKE_BUILD_TYPE=$Config -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D ACTIVITYFRAMEWORK_BUILD_TESTS=ON"
+    }
+    "build" {
+        Invoke-InVsDevCmd "`"$cmakePath`" --build `"$buildDir`""
+    }
+    "test" {
+        if (-not (Test-Path $testExe)) {
+            throw "Test executable does not exist: $testExe"
+        }
+        Invoke-InVsDevCmd "`"$testExe`""
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "cmake.useCMakePresets": "always",
+    "cmake.configureOnOpen": false,
+    "cmake.configurePreset": "windows-msvc-debug",
+    "cmake.buildPreset": "windows-msvc-debug",
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/build/windows-msvc/debug/compile_commands.json"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,104 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "CMake Configure: Windows MSVC Debug",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${workspaceFolder}\\.vscode\\scripts\\cmake-msvc.ps1",
+                "configure",
+                "Debug"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "CMake Build: Windows MSVC Debug",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${workspaceFolder}\\.vscode\\scripts\\cmake-msvc.ps1",
+                "build",
+                "Debug"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile",
+            "dependsOn": "CMake Configure: Windows MSVC Debug"
+        },
+        {
+            "label": "CMake Configure: Windows MSVC Release",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${workspaceFolder}\\.vscode\\scripts\\cmake-msvc.ps1",
+                "configure",
+                "Release"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "CMake Build: Windows MSVC Release",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${workspaceFolder}\\.vscode\\scripts\\cmake-msvc.ps1",
+                "build",
+                "Release"
+            ],
+            "group": "build",
+            "problemMatcher": "$msCompile",
+            "dependsOn": "CMake Configure: Windows MSVC Release"
+        },
+        {
+            "label": "Run ActivityFrameworkTest Debug",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${workspaceFolder}\\.vscode\\scripts\\cmake-msvc.ps1",
+                "test",
+                "Debug"
+            ],
+            "problemMatcher": [],
+            "dependsOn": "CMake Build: Windows MSVC Debug"
+        },
+        {
+            "label": "Run ActivityFrameworkTest Release",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "${workspaceFolder}\\.vscode\\scripts\\cmake-msvc.ps1",
+                "test",
+                "Release"
+            ],
+            "problemMatcher": [],
+            "dependsOn": "CMake Build: Windows MSVC Release"
+        }
+    ]
+}

--- a/ActivityFramework/Src/Components/TA_Coroutine.h
+++ b/ActivityFramework/Src/Components/TA_Coroutine.h
@@ -221,10 +221,17 @@ template <typename T, CorotuineBehavior = Lazy> struct TA_CoroutineGenerator {
         std::suspend_always initial_suspend() noexcept { return {}; }
         std::suspend_always final_suspend() noexcept { return {}; }
 
-        std::suspend_always yield_value(const T &value) {
+        struct YieldAwaiter {
+            bool await_ready() const noexcept { return false; }
+            void await_suspend(std::coroutine_handle<promise_type> h) noexcept {
+                h.promise().m_completed.store(true, std::memory_order_release);
+                h.promise().m_completed.notify_all();
+            }
+            void await_resume() noexcept {}
+        };
+
+        YieldAwaiter yield_value(const T &value) {
             m_currentValue = value;
-            m_completed.store(true, std::memory_order_release);
-            m_completed.notify_all();
             return {};
         }
 
@@ -304,10 +311,17 @@ template <typename T> struct TA_CoroutineGenerator<T, Eager> {
         std::suspend_never initial_suspend() noexcept { return {}; }
         std::suspend_always final_suspend() noexcept { return {}; }
 
-        std::suspend_always yield_value(const T &value) {
+        struct YieldAwaiter {
+            bool await_ready() const noexcept { return false; }
+            void await_suspend(std::coroutine_handle<promise_type> h) noexcept {
+                h.promise().m_completed.store(true, std::memory_order_release);
+                h.promise().m_completed.notify_all();
+            }
+            void await_resume() noexcept {}
+        };
+
+        YieldAwaiter yield_value(const T &value) {
             m_currentValue = value;
-            m_completed.store(true, std::memory_order_release);
-            m_completed.notify_all();
             return {};
         }
 
@@ -359,7 +373,7 @@ template <typename T> struct TA_CoroutineGenerator<T, Eager> {
     T value() {
         auto &pr = m_coroutineHandle.promise();
         pr.m_completed.wait(false, std::memory_order_acquire);
-        auto currentVal = pr.m_currentValue;
+        auto currentVal = std::move(pr.m_currentValue);
         pr.m_completed.store(false, std::memory_order_release);
         return std::move(currentVal);
     }

--- a/ActivityFramework/Src/Components/TA_Coroutine.h
+++ b/ActivityFramework/Src/Components/TA_Coroutine.h
@@ -30,16 +30,13 @@ template <typename T, CorotuineBehavior = Lazy> struct [[nodiscard]] TA_ManualCo
         std::optional<T> m_result{};
         std::exception_ptr m_exception{};
         std::atomic_bool m_completed{false};
-        static constexpr bool isBlockingType{true};
 
         struct FinalAwaiter {
             bool await_ready() const noexcept { return false; }
             void await_suspend(std::coroutine_handle<promise_type> h) noexcept {
                 auto &promise = h.promise();
-                if constexpr (promise_type::isBlockingType) {
-                    promise.m_completed.store(true, std::memory_order_release);
-                    promise.m_completed.notify_all();
-                }
+                promise.m_completed.store(true, std::memory_order_release);
+                promise.m_completed.notify_all();
             }
             void await_resume() noexcept {}
         };
@@ -115,16 +112,13 @@ template <typename T> struct [[nodiscard]] TA_ManualCoroutineTask<T, Eager> {
         std::optional<T> m_result{};
         std::exception_ptr m_exception{};
         std::atomic_bool m_completed{false};
-        static constexpr bool isBlockingType{true};
 
         struct FinalAwaiter {
             bool await_ready() const noexcept { return false; }
             void await_suspend(std::coroutine_handle<promise_type> h) noexcept {
                 auto &promise = h.promise();
-                if constexpr (promise_type::isBlockingType) {
-                    promise.m_completed.store(true, std::memory_order_release);
-                    promise.m_completed.notify_all();
-                }
+                promise.m_completed.store(true, std::memory_order_release);
+                promise.m_completed.notify_all();
             }
             void await_resume() noexcept {}
         };
@@ -212,7 +206,6 @@ template <typename T, CorotuineBehavior = Lazy> struct TA_CoroutineGenerator {
         T m_currentValue{};
         std::exception_ptr m_exception{};
         std::atomic_bool m_completed{false};
-        static constexpr bool isBlockingType{false};
 
         TA_CoroutineGenerator get_return_object() {
             return TA_CoroutineGenerator{std::coroutine_handle<promise_type>::from_promise(*this)};
@@ -302,7 +295,6 @@ template <typename T> struct TA_CoroutineGenerator<T, Eager> {
         T m_currentValue{};
         std::exception_ptr m_exception{};
         std::atomic_bool m_completed{false};
-        static constexpr bool isBlockingType{false};
 
         TA_CoroutineGenerator get_return_object() {
             return TA_CoroutineGenerator{std::coroutine_handle<promise_type>::from_promise(*this)};

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 # Set the project name
 project(ActivityFrameworkProject LANGUAGES CXX)
+enable_testing()
 
 # Set the C++ standard and its requirement
 set(CMAKE_CXX_STANDARD 23)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -75,9 +75,39 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
+        },
+        {
+            "name": "windows-msvc-debug",
+            "displayName": "Windows MSVC Debug",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/windows-msvc/debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "ACTIVITYFRAMEWORK_BUILD_TESTS": "ON"
+            }
+        },
+        {
+            "name": "windows-msvc-release",
+            "displayName": "Windows MSVC Release",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/windows-msvc/release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "ACTIVITYFRAMEWORK_BUILD_TESTS": "ON"
+            }
         }
     ],
     "buildPresets": [
+        {
+            "name": "windows-msvc-debug",
+            "configurePreset": "windows-msvc-debug"
+        },
+        {
+            "name": "windows-msvc-release",
+            "configurePreset": "windows-msvc-release"
+        },
         {
             "name": "android-arm64-debug",
             "configurePreset": "android-arm64-debug"

--- a/Test/ActivityFrameworkTest/TA_CoroutineTest.cpp
+++ b/Test/ActivityFrameworkTest/TA_CoroutineTest.cpp
@@ -56,3 +56,24 @@ TEST_F(TA_CoroutineTest, testCoroutineGenerator) {
     EXPECT_EQ(r2, 12);
     EXPECT_EQ(r3, 15);
 }
+
+TEST_F(TA_CoroutineTest, testLazyCoroutineGenerator) {
+    auto gen = testLazyCoroutineGenerator(m_sender.get());
+
+    int r1, r2, r3;
+    CoreAsync::TA_Connection::active(m_sender.get(), &CoroutineTestSender::sendSignal, 3);
+    gen.start();
+    r1 = gen.value();
+    gen.next();
+
+    CoreAsync::TA_Connection::active(m_sender.get(), &CoroutineTestSender::sendSignal, 4);
+    r2 = gen.value();
+    gen.next(); 
+
+    CoreAsync::TA_Connection::active(m_sender.get(), &CoroutineTestSender::sendSignal, 5);
+    r3 = gen.value();
+    
+    EXPECT_EQ(r1, 9);
+    EXPECT_EQ(r2, 12);
+    EXPECT_EQ(r3, 15);
+}

--- a/Test/ActivityFrameworkTest/TA_CoroutineTest.cpp
+++ b/Test/ActivityFrameworkTest/TA_CoroutineTest.cpp
@@ -61,8 +61,8 @@ TEST_F(TA_CoroutineTest, testLazyCoroutineGenerator) {
     auto gen = testLazyCoroutineGenerator(m_sender.get());
 
     int r1, r2, r3;
-    CoreAsync::TA_Connection::active(m_sender.get(), &CoroutineTestSender::sendSignal, 3);
     gen.start();
+    CoreAsync::TA_Connection::active(m_sender.get(), &CoroutineTestSender::sendSignal, 3);
     r1 = gen.value();
     gen.next();
 

--- a/Test/ActivityFrameworkTest/TA_CoroutineTest.h
+++ b/Test/ActivityFrameworkTest/TA_CoroutineTest.h
@@ -45,6 +45,17 @@ class TA_CoroutineTest : public ::testing::Test {
         co_return;
     }
 
+    CoreAsync::TA_CoroutineGenerator<int, CoreAsync::Lazy> testLazyCoroutineGenerator(CoroutineTestSender *pSender) {
+        while (true) {
+            auto val = co_await CoreAsync::TA_SignalAwaitable(pSender, &CoroutineTestSender::sendSignal);
+            co_yield val * 3;
+            if (val > 10) {
+                break;
+            }
+        }
+        co_return;
+    }
+
     std::size_t m_count{0};
     std::shared_ptr<CoroutineTestSender> m_sender{nullptr};
 };

--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -78,5 +78,7 @@ elseif(UNIX)
     target_link_directories(ActivityFrameworkTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/googletest/output/Linux)
 endif()
 
+add_test(NAME ActivityFrameworkTest COMMAND ActivityFrameworkTest)
+
 install(TARGETS ActivityFrameworkTest
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Introduce a YieldAwaiter for both Lazy and Eager TA_CoroutineGenerator::yield_value that performs m_completed.store(true) and notify_all() inside await_suspend, instead of doing the notifications inline. This ensures the completion flag and notifications occur as part of the suspension handshake. Also change Eager::value() to move the stored current value (std::move) to avoid an extra copy. These changes improve correctness around coroutine suspension/notification and reduce unnecessary copying.